### PR TITLE
[TS] LPS-131525

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/UserGroupGroupRoleImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserGroupGroupRoleImpl.java
@@ -14,10 +14,12 @@
 
 package com.liferay.portal.model.impl;
 
+import com.liferay.petra.lang.HashUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.model.UserGroupGroupRole;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
@@ -27,6 +29,28 @@ import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
  * @author Norbert Kocsis
  */
 public class UserGroupGroupRoleImpl extends UserGroupGroupRoleBaseImpl {
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof UserGroupGroupRole)) {
+			return false;
+		}
+
+		UserGroupGroupRole userGroupGroupRole = (UserGroupGroupRole)object;
+
+		if ((getUserGroupId() == userGroupGroupRole.getUserGroupId()) &&
+			(getGroupId() == userGroupGroupRole.getGroupId()) &&
+			(getRoleId() == userGroupGroupRole.getRoleId())) {
+
+			return true;
+		}
+
+		return false;
+	}
 
 	@Override
 	public Group getGroup() throws PortalException {
@@ -41,6 +65,15 @@ public class UserGroupGroupRoleImpl extends UserGroupGroupRoleBaseImpl {
 	@Override
 	public UserGroup getUserGroup() throws PortalException {
 		return UserGroupLocalServiceUtil.getUserGroup(getUserGroupId());
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = HashUtil.hash(0, getUserGroupId());
+
+		hash = HashUtil.hash(hash, getGroupId());
+
+		return HashUtil.hash(hash, getRoleId());
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/model/UserGroupGroupRole.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/UserGroupGroupRole.java
@@ -57,6 +57,9 @@ public interface UserGroupGroupRole
 
 			};
 
+	@Override
+	public boolean equals(Object object);
+
 	public Group getGroup()
 		throws com.liferay.portal.kernel.exception.PortalException;
 
@@ -65,5 +68,7 @@ public interface UserGroupGroupRole
 
 	public UserGroup getUserGroup()
 		throws com.liferay.portal.kernel.exception.PortalException;
+
+	public int hashCode();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/model/UserGroupGroupRoleWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/UserGroupGroupRoleWrapper.java
@@ -99,6 +99,11 @@ public class UserGroupGroupRoleWrapper
 		}
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		return model.equals(object);
+	}
+
 	/**
 	 * Returns the company ID of this user group group role.
 	 *
@@ -198,6 +203,11 @@ public class UserGroupGroupRoleWrapper
 	@Override
 	public long getUserGroupId() {
 		return model.getUserGroupId();
+	}
+
+	@Override
+	public int hashCode() {
+		return model.hashCode();
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.2.0


### PR DESCRIPTION
From @balazssk:

> [VerifyGroup](https://github.com/liferay/liferay-portal/blob/8625f5ed6c4ca75a6520153cab32d121d75fa2bb/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java#L233) uses Collection.contains to filter for userGroupGroupRoles that are present in the Staging group but not in the Live group. This however won't work with the default Object#equals, so I'd like to add this implementation.
> 
> The solution is based on https://github.com/liferay/liferay-portal/commit/35e3d3329ccba0262adb03fc4b81dc8c75618e27#diff-e89f78642ff2532ec9fbd54692f8cf0a1168886d7c7337694925e3299d9f78b9 .
> 
> Can you please review?
> https://issues.liferay.com/browse/LPS-131525 

This issue is unknown on how to reproduce cleanly, however the solution looks safe and is very similar to several other model implementations.