### PR TITLE
[TS] LPS-133124

### DIFF
--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/persistence/test/UserFinderTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/persistence/test/UserFinderTest.java
@@ -382,6 +382,23 @@ public class UserFinderTest {
 		Assert.assertEquals(users.toString(), 1, users.size());
 	}
 
+	@Test
+	public void testParseQueryWithLimit() throws Exception {
+		String[] firstNames = {null};
+		String[] middleNames = {null};
+		String[] lastNames = {null};
+		String[] screenNames = {null};
+		String[] emailAddresses = {null};
+
+		_userFinder.findByC_FN_MN_LN_SN_EA_S(
+			TestPropsValues.getCompanyId(), firstNames, middleNames, lastNames,
+			screenNames, emailAddresses, 0,
+			LinkedHashMapBuilder.<String, Object>put(
+				"announcementsDeliveryEmailOrSms", "general"
+			).build(),
+			true, 0, 1, null);
+	}
+
 	private void _setOrganizationsMembershipStrict(boolean strict)
 		throws Exception {
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -915,15 +915,11 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 			StringBundler sb = new StringBundler((paramsList.size() * 3) + 2);
 
 			for (int i = 0; i < paramsList.size(); i++) {
-				if (i == 0) {
-					sb.append(StringPool.OPEN_PARENTHESIS);
-				}
-				else {
-					sb.append(" UNION (");
+				if (i >= 1) {
+					sb.append(" UNION ");
 				}
 
 				sb.append(replaceJoinAndWhere(sql, paramsList.get(i)));
-				sb.append(StringPool.CLOSE_PARENTHESIS);
 			}
 
 			if (orderByComparator != null) {

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -912,25 +912,33 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 				sql = StringUtil.removeSubstring(sql, _STATUS_SQL);
 			}
 
-			StringBundler sb = new StringBundler((paramsList.size() * 3) + 2);
-
-			for (int i = 0; i < paramsList.size(); i++) {
-				if (i == 0) {
-					sb.append(replaceJoinAndWhere(sql, paramsList.get(i)));
-				}
-				else {
-					sb.append(" UNION (");
-					sb.append(replaceJoinAndWhere(sql, paramsList.get(i)));
-					sb.append(StringPool.CLOSE_PARENTHESIS);
-				}
-			}
+			int initialCapacity = (paramsList.size() * 3) - 2;
 
 			if (orderByComparator != null) {
-				sb.append(" ORDER BY ");
-				sb.append(orderByComparator.toString());
+				initialCapacity += 2;
 			}
 
-			sql = sb.toString();
+			if (initialCapacity > 0) {
+				StringBundler sb = new StringBundler(initialCapacity);
+
+				for (int i = 0; i < paramsList.size(); i++) {
+					if (i == 0) {
+						sb.append(replaceJoinAndWhere(sql, paramsList.get(i)));
+					}
+					else {
+						sb.append(" UNION (");
+						sb.append(replaceJoinAndWhere(sql, paramsList.get(i)));
+						sb.append(StringPool.CLOSE_PARENTHESIS);
+					}
+				}
+
+				if (orderByComparator != null) {
+					sb.append(" ORDER BY ");
+					sb.append(orderByComparator.toString());
+				}
+
+				sql = sb.toString();
+			}
 
 			sql = CustomSQLUtil.replaceAndOperator(sql, andOperator);
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -915,11 +915,14 @@ public class UserFinderImpl extends UserFinderBaseImpl implements UserFinder {
 			StringBundler sb = new StringBundler((paramsList.size() * 3) + 2);
 
 			for (int i = 0; i < paramsList.size(); i++) {
-				if (i >= 1) {
-					sb.append(" UNION ");
+				if (i == 0) {
+					sb.append(replaceJoinAndWhere(sql, paramsList.get(i)));
 				}
-
-				sb.append(replaceJoinAndWhere(sql, paramsList.get(i)));
+				else {
+					sb.append(" UNION (");
+					sb.append(replaceJoinAndWhere(sql, paramsList.get(i)));
+					sb.append(StringPool.CLOSE_PARENTHESIS);
+				}
 			}
 
 			if (orderByComparator != null) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-133124

From @jesseyeh-liferay 

> Third-party code adds a `LIMIT` clause to the end of the query, which [JSqlParser parses out](https://github.com/liferay/liferay-portal/blob/226c3227101285be39c1743f46b1f411d0eff0a1/modules/apps/static/portal/portal-change-tracking/src/main/java/com/liferay/portal/change/tracking/internal/CTSQLTransformerImpl.java#L217-L218). Removing the outermost set of parentheses from the query works around this issue and preserves the `LIMIT` clause.
> 
> The following is an example of such a query -- there are a total of 15 parameters. When parsed by JSqlParser, the `LIMIT` clause at the end gets removed, which then causes an exception to occur due to the total number of parameters being off by one:
> ```
> (
>   SELECT
>     DISTINCT User_.userId AS userId
>   FROM
>     User_
>     INNER JOIN AnnouncementsDelivery ON AnnouncementsDelivery.userId = User_.userId
>   WHERE
>     (AnnouncementsDelivery.type_ = ?)
>     AND (
>       (AnnouncementsDelivery.email = true)
>       OR (AnnouncementsDelivery.sms = true)
>     )
>     AND (User_.companyId = ?)
>     AND (User_.defaultUser = ?)
>     AND (
>       (
>         LOWER(User_.firstName) LIKE ?
>         OR ? IS NULL
>       )
>       AND (
>         LOWER(User_.middleName) LIKE ?
>         OR ? IS NULL
>       )
>       AND (
>         LOWER(User_.lastName) LIKE ?
>         OR ? IS NULL
>       )
>       AND (
>         LOWER(User_.screenName) LIKE ?
>         OR ? IS NULL
>       )
>       AND (
>         LOWER(User_.emailAddress) LIKE ?
>         OR ? IS NULL
>       )
>     )
>     AND (User_.status = ?)
> )
> limit
>   ?
> ```
> 
> **Additional Notes**
> Given a query of the form:
> ```
> QUERY A UNION QUERY B LIMIT X
> ```
> The parser does not parse out the LIMIT clause (correct behavior) in the following scenarios:
> ```
> (QUERY  A) UNION (QUERY B) LIMIT X
> (QUERY  A  UNION  QUERY B) LIMIT X
>  QUERY  A  UNION (QUERY B) LIMIT X
> (QUERY) A  UNION  QUERY B  LIMIT X
>  QUERY  A  UNION  QUERY B  LIMIT X
>  QUERY  A                  LIMIT X
> ```
> However, the parser does parse out the `LIMIT` clause (incorrect behavior) in the following scenario:
> ```
> (QUERY A) LIMIT X ==> QUERY A
> ```