### PR TITLE
LPS-135085 Index error when switching from Sidecar to Production Mode

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelToDDMFormConverter.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelToDDMFormConverter.java
@@ -288,12 +288,7 @@ public class ConfigurationModelToDDMFormConverter {
 			return DDMFormFieldType.LOCALIZABLE_TEXT;
 		}
 
-		ConfigurationFieldOptionsProvider configurationFieldOptionsProvider =
-			getConfigurationFieldOptionsProvider(attributeDefinition);
-
-		if (!SetUtil.isEmpty(ddmFormFieldOptions.getOptionsValues()) ||
-			(configurationFieldOptionsProvider != null)) {
-
+		if (SetUtil.isNotEmpty(ddmFormFieldOptions.getOptionsValues())) {
 			return DDMFormFieldType.SELECT;
 		}
 


### PR DESCRIPTION
This is an update for [LPS-135085](https://issues.liferay.com/browse/LPS-135085).

-----------------

@pei-jung @4lejandrito @BryanEngler this solution forces a field with no options to be a text field, whether or not an options provider is registered. This addresses the problem of a select field with no options submitting "[]" as a value (main problem from the ticket).

I also am considering adding a second change that disables the field if an option provider is registered but no options are contributed: https://github.com/drewbrokke/liferay-portal/commit/9cb157634b83ea535e0040e924d480ef96636581. 

There are drawbacks to both approaches:
1. If we leave the field enabled, an admin could enter whatever value they want, which may be an issue if only certain options are valid. This could be alleviated by simply hiding the field with a visibility controller if there are no options (but would be up to the app developer to implement).
2. If we disable the field, we don't allow the possibility that the app developer might _want_ the user to be able to enter a custom value. This seems less likely, but I wanted to bring it up.

Thoughts?

------------------
cc @pei-jung @alee8888 @ChrisKian @patriciajeanperez @lr-leo