### PR TITLE
LPS-136040 - Tags do not display in Tags selector for Account

### DIFF
--- a/modules/apps/asset/asset-tags-selector-web/src/main/java/com/liferay/asset/tags/selector/web/internal/display/context/AssetTagsSelectorDisplayContext.java
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/java/com/liferay/asset/tags/selector/web/internal/display/context/AssetTagsSelectorDisplayContext.java
@@ -170,12 +170,16 @@ public class AssetTagsSelectorDisplayContext {
 		_groupIds = StringUtil.split(
 			ParamUtil.getString(_httpServletRequest, "groupIds"), 0L);
 
-		if (ArrayUtil.isEmpty(_groupIds)) {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)_httpServletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
+		if (ArrayUtil.isEmpty(_groupIds)) {
 			_groupIds = new long[] {themeDisplay.getScopeGroupId()};
+		}
+		else {
+			_groupIds = ArrayUtil.append(
+				_groupIds, themeDisplay.getScopeGroupId());
 		}
 
 		return _groupIds;


### PR DESCRIPTION
From @Odrakir1:

> This issue was caused by a missing group id, in this case, the Global group id. The asset was being fetched by the Control Panel's group id only, adding the Global group id in the search solved the problem.
> 
> 
> 
> https://issues.liferay.com/browse/LPS-136040