### PR TITLE
LPS-130793 Unify the AccountUser object with the UserAccount object in the account-rest module schema.

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountRoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountRoleResource.java
@@ -51,12 +51,12 @@ public interface AccountRoleResource {
 
 	public void deleteAccountRoleUserAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
-			String accountUserExternalReferenceCode)
+			String userAccountExternalReferenceCode)
 		throws Exception;
 
 	public void postAccountRoleUserAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
-			String accountUserExternalReferenceCode)
+			String userAccountExternalReferenceCode)
 		throws Exception;
 
 	public Page<AccountRole> getAccountRolesByExternalReferenceCodePage(
@@ -77,11 +77,11 @@ public interface AccountRoleResource {
 		throws Exception;
 
 	public void deleteAccountRoleUserAssociation(
-			Long accountId, Long accountRoleId, Long accountUserId)
+			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
 	public void postAccountRoleUserAssociation(
-			Long accountId, Long accountRoleId, Long accountUserId)
+			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountRoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountRoleResource.java
@@ -29,6 +29,7 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.osgi.annotation.versioning.ProviderType;
@@ -49,38 +50,45 @@ public interface AccountRoleResource {
 		return FactoryHolder.factory.create();
 	}
 
-	public void deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
-			String accountExternalReferenceCode, Long accountRoleId,
-			String userAccountExternalReferenceCode)
+	public void
+			deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
+				String accountExternalReferenceCode, Long accountRoleId,
+				String userAccountExternalReferenceCode)
 		throws Exception;
 
-	public void postAccountRoleUserAccountAssociationByExternalReferenceCode(
-			String accountExternalReferenceCode, Long accountRoleId,
-			String userAccountExternalReferenceCode)
+	public void
+			postAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
+				String accountExternalReferenceCode, Long accountRoleId,
+				String userAccountExternalReferenceCode)
 		throws Exception;
 
-	public Page<AccountRole> getAccountRolesByExternalReferenceCodePage(
+	public Page<AccountRole> getAccountAccountRolesByExternalReferenceCodePage(
 			String externalReferenceCode, String keywords,
 			Pagination pagination, Sort[] sorts)
 		throws Exception;
 
-	public AccountRole postAccountRoleByExternalReferenceCode(
+	public AccountRole postAccountAccountRoleByExternalReferenceCode(
 			String externalReferenceCode, AccountRole accountRole)
 		throws Exception;
 
-	public Page<AccountRole> getAccountRolesPage(
+	public Page<AccountRole> getAccountAccountRolesPage(
 			Long accountId, String keywords, Pagination pagination,
 			Sort[] sorts)
 		throws Exception;
 
-	public AccountRole postAccountRole(Long accountId, AccountRole accountRole)
+	public AccountRole postAccountAccountRole(
+			Long accountId, AccountRole accountRole)
 		throws Exception;
 
-	public void deleteAccountRoleUserAccountAssociation(
+	public Response postAccountAccountRoleBatch(
+			Long accountId, String callbackURL, Object object)
+		throws Exception;
+
+	public void deleteAccountAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
-	public void postAccountRoleUserAccountAssociation(
+	public void postAccountAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountRoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountRoleResource.java
@@ -49,12 +49,12 @@ public interface AccountRoleResource {
 		return FactoryHolder.factory.create();
 	}
 
-	public void deleteAccountRoleUserAssociationByExternalReferenceCode(
+	public void deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
 			String userAccountExternalReferenceCode)
 		throws Exception;
 
-	public void postAccountRoleUserAssociationByExternalReferenceCode(
+	public void postAccountRoleUserAccountAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
 			String userAccountExternalReferenceCode)
 		throws Exception;
@@ -76,11 +76,11 @@ public interface AccountRoleResource {
 	public AccountRole postAccountRole(Long accountId, AccountRole accountRole)
 		throws Exception;
 
-	public void deleteAccountRoleUserAssociation(
+	public void deleteAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
-	public void postAccountRoleUserAssociation(
+	public void postAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
@@ -51,51 +51,57 @@ public interface UserAccountResource {
 		return FactoryHolder.factory.create();
 	}
 
-	public Page<UserAccount> getAccountUsersByExternalReferenceCodePage(
+	public Page<UserAccount> getAccountUserAccountsByExternalReferenceCodePage(
 			String externalReferenceCode, String search, Filter filter,
 			Pagination pagination, Sort[] sorts)
 		throws Exception;
 
-	public UserAccount postAccountUserByExternalReferenceCode(
+	public UserAccount postAccountUserAccountByExternalReferenceCode(
 			String externalReferenceCode, UserAccount userAccount)
 		throws Exception;
 
-	public void deleteAccountUsersByExternalReferenceCodeByEmailAddress(
+	public void deleteAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String[] strings)
 		throws Exception;
 
-	public void postAccountUsersByExternalReferenceCodeByEmailAddress(
+	public void postAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String[] strings)
 		throws Exception;
 
-	public void deleteAccountUserByExternalReferenceCodeByEmailAddress(
+	public void deleteAccountUserAccountByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String emailAddress)
 		throws Exception;
 
-	public void postAccountUserByExternalReferenceCodeByEmailAddress(
+	public void postAccountUserAccountByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String emailAddress)
 		throws Exception;
 
-	public Page<UserAccount> getAccountUsersPage(
+	public Page<UserAccount> getAccountUserAccountsPage(
 			Long accountId, String search, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception;
 
-	public UserAccount postAccountUser(Long accountId, UserAccount userAccount)
+	public UserAccount postAccountUserAccount(
+			Long accountId, UserAccount userAccount)
 		throws Exception;
 
-	public void deleteAccountUsersByEmailAddress(
+	public Response postAccountUserAccountBatch(
+			Long accountId, String callbackURL, Object object)
+		throws Exception;
+
+	public void deleteAccountUserAccountsByEmailAddress(
 			Long accountId, String[] strings)
 		throws Exception;
 
-	public void postAccountUsersByEmailAddress(Long accountId, String[] strings)
+	public void postAccountUserAccountsByEmailAddress(
+			Long accountId, String[] strings)
 		throws Exception;
 
-	public void deleteAccountUserByEmailAddress(
+	public void deleteAccountUserAccountByEmailAddress(
 			Long accountId, String emailAddress)
 		throws Exception;
 
-	public void postAccountUserByEmailAddress(
+	public void postAccountUserAccountByEmailAddress(
 			Long accountId, String emailAddress)
 		throws Exception;
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountRoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountRoleResource.java
@@ -40,24 +40,24 @@ public interface AccountRoleResource {
 		return new Builder();
 	}
 
-	public void deleteAccountRoleUserAssociationByExternalReferenceCode(
+	public void deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
 			String userAccountExternalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			deleteAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
+			deleteAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 				String accountExternalReferenceCode, Long accountRoleId,
 				String userAccountExternalReferenceCode)
 		throws Exception;
 
-	public void postAccountRoleUserAssociationByExternalReferenceCode(
+	public void postAccountRoleUserAccountAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
 			String userAccountExternalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			postAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
+			postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 				String accountExternalReferenceCode, Long accountRoleId,
 				String userAccountExternalReferenceCode)
 		throws Exception;
@@ -99,21 +99,22 @@ public interface AccountRoleResource {
 			Long accountId, AccountRole accountRole)
 		throws Exception;
 
-	public void deleteAccountRoleUserAssociation(
+	public void deleteAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			deleteAccountRoleUserAssociationHttpResponse(
+			deleteAccountRoleUserAccountAssociationHttpResponse(
 				Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
-	public void postAccountRoleUserAssociation(
+	public void postAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse postAccountRoleUserAssociationHttpResponse(
-			Long accountId, Long accountRoleId, Long userAccountId)
+	public HttpInvoker.HttpResponse
+			postAccountRoleUserAccountAssociationHttpResponse(
+				Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
 	public static class Builder {
@@ -187,13 +188,14 @@ public interface AccountRoleResource {
 
 	public static class AccountRoleResourceImpl implements AccountRoleResource {
 
-		public void deleteAccountRoleUserAssociationByExternalReferenceCode(
-				String accountExternalReferenceCode, Long accountRoleId,
-				String userAccountExternalReferenceCode)
+		public void
+				deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
+					String accountExternalReferenceCode, Long accountRoleId,
+					String userAccountExternalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				deleteAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
+				deleteAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					accountExternalReferenceCode, accountRoleId,
 					userAccountExternalReferenceCode);
 
@@ -235,7 +237,7 @@ public interface AccountRoleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				deleteAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
+				deleteAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					String accountExternalReferenceCode, Long accountRoleId,
 					String userAccountExternalReferenceCode)
 			throws Exception {
@@ -279,13 +281,14 @@ public interface AccountRoleResource {
 			return httpInvoker.invoke();
 		}
 
-		public void postAccountRoleUserAssociationByExternalReferenceCode(
-				String accountExternalReferenceCode, Long accountRoleId,
-				String userAccountExternalReferenceCode)
+		public void
+				postAccountRoleUserAccountAssociationByExternalReferenceCode(
+					String accountExternalReferenceCode, Long accountRoleId,
+					String userAccountExternalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
+				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					accountExternalReferenceCode, accountRoleId,
 					userAccountExternalReferenceCode);
 
@@ -327,7 +330,7 @@ public interface AccountRoleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
+				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					String accountExternalReferenceCode, Long accountRoleId,
 					String userAccountExternalReferenceCode)
 			throws Exception {
@@ -742,12 +745,12 @@ public interface AccountRoleResource {
 			return httpInvoker.invoke();
 		}
 
-		public void deleteAccountRoleUserAssociation(
+		public void deleteAccountRoleUserAccountAssociation(
 				Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				deleteAccountRoleUserAssociationHttpResponse(
+				deleteAccountRoleUserAccountAssociationHttpResponse(
 					accountId, accountRoleId, userAccountId);
 
 			String content = httpResponse.getContent();
@@ -788,7 +791,7 @@ public interface AccountRoleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				deleteAccountRoleUserAssociationHttpResponse(
+				deleteAccountRoleUserAccountAssociationHttpResponse(
 					Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 
@@ -828,12 +831,12 @@ public interface AccountRoleResource {
 			return httpInvoker.invoke();
 		}
 
-		public void postAccountRoleUserAssociation(
+		public void postAccountRoleUserAccountAssociation(
 				Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postAccountRoleUserAssociationHttpResponse(
+				postAccountRoleUserAccountAssociationHttpResponse(
 					accountId, accountRoleId, userAccountId);
 
 			String content = httpResponse.getContent();
@@ -874,7 +877,7 @@ public interface AccountRoleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAccountRoleUserAssociationHttpResponse(
+				postAccountRoleUserAccountAssociationHttpResponse(
 					Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountRoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountRoleResource.java
@@ -40,80 +40,91 @@ public interface AccountRoleResource {
 		return new Builder();
 	}
 
-	public void deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
-			String accountExternalReferenceCode, Long accountRoleId,
-			String userAccountExternalReferenceCode)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse
-			deleteAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+	public void
+			deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
 				String accountExternalReferenceCode, Long accountRoleId,
 				String userAccountExternalReferenceCode)
 		throws Exception;
 
-	public void postAccountRoleUserAccountAssociationByExternalReferenceCode(
-			String accountExternalReferenceCode, Long accountRoleId,
-			String userAccountExternalReferenceCode)
-		throws Exception;
-
 	public HttpInvoker.HttpResponse
-			postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+			deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 				String accountExternalReferenceCode, Long accountRoleId,
 				String userAccountExternalReferenceCode)
 		throws Exception;
 
-	public Page<AccountRole> getAccountRolesByExternalReferenceCodePage(
+	public void
+			postAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
+				String accountExternalReferenceCode, Long accountRoleId,
+				String userAccountExternalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postAccountAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+				String accountExternalReferenceCode, Long accountRoleId,
+				String userAccountExternalReferenceCode)
+		throws Exception;
+
+	public Page<AccountRole> getAccountAccountRolesByExternalReferenceCodePage(
 			String externalReferenceCode, String keywords,
 			Pagination pagination, String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getAccountRolesByExternalReferenceCodePageHttpResponse(
+			getAccountAccountRolesByExternalReferenceCodePageHttpResponse(
 				String externalReferenceCode, String keywords,
 				Pagination pagination, String sortString)
 		throws Exception;
 
-	public AccountRole postAccountRoleByExternalReferenceCode(
+	public AccountRole postAccountAccountRoleByExternalReferenceCode(
 			String externalReferenceCode, AccountRole accountRole)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			postAccountRoleByExternalReferenceCodeHttpResponse(
+			postAccountAccountRoleByExternalReferenceCodeHttpResponse(
 				String externalReferenceCode, AccountRole accountRole)
 		throws Exception;
 
-	public Page<AccountRole> getAccountRolesPage(
+	public Page<AccountRole> getAccountAccountRolesPage(
 			Long accountId, String keywords, Pagination pagination,
 			String sortString)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse getAccountRolesPageHttpResponse(
+	public HttpInvoker.HttpResponse getAccountAccountRolesPageHttpResponse(
 			Long accountId, String keywords, Pagination pagination,
 			String sortString)
 		throws Exception;
 
-	public AccountRole postAccountRole(Long accountId, AccountRole accountRole)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse postAccountRoleHttpResponse(
+	public AccountRole postAccountAccountRole(
 			Long accountId, AccountRole accountRole)
 		throws Exception;
 
-	public void deleteAccountRoleUserAccountAssociation(
+	public HttpInvoker.HttpResponse postAccountAccountRoleHttpResponse(
+			Long accountId, AccountRole accountRole)
+		throws Exception;
+
+	public void postAccountAccountRoleBatch(
+			Long accountId, String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postAccountAccountRoleBatchHttpResponse(
+			Long accountId, String callbackURL, Object object)
+		throws Exception;
+
+	public void deleteAccountAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			deleteAccountRoleUserAccountAssociationHttpResponse(
+			deleteAccountAccountRoleUserAccountAssociationHttpResponse(
 				Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
-	public void postAccountRoleUserAccountAssociation(
+	public void postAccountAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			postAccountRoleUserAccountAssociationHttpResponse(
+			postAccountAccountRoleUserAccountAssociationHttpResponse(
 				Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
@@ -189,13 +200,13 @@ public interface AccountRoleResource {
 	public static class AccountRoleResourceImpl implements AccountRoleResource {
 
 		public void
-				deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
+				deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
 					String accountExternalReferenceCode, Long accountRoleId,
 					String userAccountExternalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				deleteAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+				deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					accountExternalReferenceCode, accountRoleId,
 					userAccountExternalReferenceCode);
 
@@ -237,7 +248,7 @@ public interface AccountRoleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				deleteAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+				deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					String accountExternalReferenceCode, Long accountRoleId,
 					String userAccountExternalReferenceCode)
 			throws Exception {
@@ -282,13 +293,13 @@ public interface AccountRoleResource {
 		}
 
 		public void
-				postAccountRoleUserAccountAssociationByExternalReferenceCode(
+				postAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
 					String accountExternalReferenceCode, Long accountRoleId,
 					String userAccountExternalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+				postAccountAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					accountExternalReferenceCode, accountRoleId,
 					userAccountExternalReferenceCode);
 
@@ -330,7 +341,7 @@ public interface AccountRoleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+				postAccountAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					String accountExternalReferenceCode, Long accountRoleId,
 					String userAccountExternalReferenceCode)
 			throws Exception {
@@ -374,13 +385,14 @@ public interface AccountRoleResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<AccountRole> getAccountRolesByExternalReferenceCodePage(
-				String externalReferenceCode, String keywords,
-				Pagination pagination, String sortString)
+		public Page<AccountRole>
+				getAccountAccountRolesByExternalReferenceCodePage(
+					String externalReferenceCode, String keywords,
+					Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getAccountRolesByExternalReferenceCodePageHttpResponse(
+				getAccountAccountRolesByExternalReferenceCodePageHttpResponse(
 					externalReferenceCode, keywords, pagination, sortString);
 
 			String content = httpResponse.getContent();
@@ -421,7 +433,7 @@ public interface AccountRoleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getAccountRolesByExternalReferenceCodePageHttpResponse(
+				getAccountAccountRolesByExternalReferenceCodePageHttpResponse(
 					String externalReferenceCode, String keywords,
 					Pagination pagination, String sortString)
 			throws Exception {
@@ -475,12 +487,12 @@ public interface AccountRoleResource {
 			return httpInvoker.invoke();
 		}
 
-		public AccountRole postAccountRoleByExternalReferenceCode(
+		public AccountRole postAccountAccountRoleByExternalReferenceCode(
 				String externalReferenceCode, AccountRole accountRole)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postAccountRoleByExternalReferenceCodeHttpResponse(
+				postAccountAccountRoleByExternalReferenceCodeHttpResponse(
 					externalReferenceCode, accountRole);
 
 			String content = httpResponse.getContent();
@@ -521,7 +533,7 @@ public interface AccountRoleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAccountRoleByExternalReferenceCodeHttpResponse(
+				postAccountAccountRoleByExternalReferenceCodeHttpResponse(
 					String externalReferenceCode, AccountRole accountRole)
 			throws Exception {
 
@@ -561,13 +573,13 @@ public interface AccountRoleResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<AccountRole> getAccountRolesPage(
+		public Page<AccountRole> getAccountAccountRolesPage(
 				Long accountId, String keywords, Pagination pagination,
 				String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getAccountRolesPageHttpResponse(
+				getAccountAccountRolesPageHttpResponse(
 					accountId, keywords, pagination, sortString);
 
 			String content = httpResponse.getContent();
@@ -607,7 +619,7 @@ public interface AccountRoleResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse getAccountRolesPageHttpResponse(
+		public HttpInvoker.HttpResponse getAccountAccountRolesPageHttpResponse(
 				Long accountId, String keywords, Pagination pagination,
 				String sortString)
 			throws Exception {
@@ -661,12 +673,12 @@ public interface AccountRoleResource {
 			return httpInvoker.invoke();
 		}
 
-		public AccountRole postAccountRole(
+		public AccountRole postAccountAccountRole(
 				Long accountId, AccountRole accountRole)
 			throws Exception {
 
-			HttpInvoker.HttpResponse httpResponse = postAccountRoleHttpResponse(
-				accountId, accountRole);
+			HttpInvoker.HttpResponse httpResponse =
+				postAccountAccountRoleHttpResponse(accountId, accountRole);
 
 			String content = httpResponse.getContent();
 
@@ -705,7 +717,7 @@ public interface AccountRoleResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse postAccountRoleHttpResponse(
+		public HttpInvoker.HttpResponse postAccountAccountRoleHttpResponse(
 				Long accountId, AccountRole accountRole)
 			throws Exception {
 
@@ -745,12 +757,91 @@ public interface AccountRoleResource {
 			return httpInvoker.invoke();
 		}
 
-		public void deleteAccountRoleUserAccountAssociation(
+		public void postAccountAccountRoleBatch(
+				Long accountId, String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAccountAccountRoleBatchHttpResponse(
+					accountId, callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postAccountAccountRoleBatchHttpResponse(
+				Long accountId, String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port +
+						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/batch");
+
+			httpInvoker.path("accountId", accountId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteAccountAccountRoleUserAccountAssociation(
 				Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				deleteAccountRoleUserAccountAssociationHttpResponse(
+				deleteAccountAccountRoleUserAccountAssociationHttpResponse(
 					accountId, accountRoleId, userAccountId);
 
 			String content = httpResponse.getContent();
@@ -791,7 +882,7 @@ public interface AccountRoleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				deleteAccountRoleUserAccountAssociationHttpResponse(
+				deleteAccountAccountRoleUserAccountAssociationHttpResponse(
 					Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 
@@ -831,12 +922,12 @@ public interface AccountRoleResource {
 			return httpInvoker.invoke();
 		}
 
-		public void postAccountRoleUserAccountAssociation(
+		public void postAccountAccountRoleUserAccountAssociation(
 				Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postAccountRoleUserAccountAssociationHttpResponse(
+				postAccountAccountRoleUserAccountAssociationHttpResponse(
 					accountId, accountRoleId, userAccountId);
 
 			String content = httpResponse.getContent();
@@ -877,7 +968,7 @@ public interface AccountRoleResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAccountRoleUserAccountAssociationHttpResponse(
+				postAccountAccountRoleUserAccountAssociationHttpResponse(
 					Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountRoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountRoleResource.java
@@ -42,24 +42,24 @@ public interface AccountRoleResource {
 
 	public void deleteAccountRoleUserAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
-			String accountUserExternalReferenceCode)
+			String userAccountExternalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			deleteAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String accountUserExternalReferenceCode)
+				String userAccountExternalReferenceCode)
 		throws Exception;
 
 	public void postAccountRoleUserAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
-			String accountUserExternalReferenceCode)
+			String userAccountExternalReferenceCode)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			postAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String accountUserExternalReferenceCode)
+				String userAccountExternalReferenceCode)
 		throws Exception;
 
 	public Page<AccountRole> getAccountRolesByExternalReferenceCodePage(
@@ -100,20 +100,20 @@ public interface AccountRoleResource {
 		throws Exception;
 
 	public void deleteAccountRoleUserAssociation(
-			Long accountId, Long accountRoleId, Long accountUserId)
+			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			deleteAccountRoleUserAssociationHttpResponse(
-				Long accountId, Long accountRoleId, Long accountUserId)
+				Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
 	public void postAccountRoleUserAssociation(
-			Long accountId, Long accountRoleId, Long accountUserId)
+			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postAccountRoleUserAssociationHttpResponse(
-			Long accountId, Long accountRoleId, Long accountUserId)
+			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception;
 
 	public static class Builder {
@@ -189,13 +189,13 @@ public interface AccountRoleResource {
 
 		public void deleteAccountRoleUserAssociationByExternalReferenceCode(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String accountUserExternalReferenceCode)
+				String userAccountExternalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				deleteAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
 					accountExternalReferenceCode, accountRoleId,
-					accountUserExternalReferenceCode);
+					userAccountExternalReferenceCode);
 
 			String content = httpResponse.getContent();
 
@@ -237,7 +237,7 @@ public interface AccountRoleResource {
 		public HttpInvoker.HttpResponse
 				deleteAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
 					String accountExternalReferenceCode, Long accountRoleId,
-					String accountUserExternalReferenceCode)
+					String userAccountExternalReferenceCode)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -264,14 +264,14 @@ public interface AccountRoleResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/account-users/{accountUserExternalReferenceCode}");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/{userAccountExternalReferenceCode}");
 
 			httpInvoker.path(
 				"accountExternalReferenceCode", accountExternalReferenceCode);
 			httpInvoker.path("accountRoleId", accountRoleId);
 			httpInvoker.path(
-				"accountUserExternalReferenceCode",
-				accountUserExternalReferenceCode);
+				"userAccountExternalReferenceCode",
+				userAccountExternalReferenceCode);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -281,13 +281,13 @@ public interface AccountRoleResource {
 
 		public void postAccountRoleUserAssociationByExternalReferenceCode(
 				String accountExternalReferenceCode, Long accountRoleId,
-				String accountUserExternalReferenceCode)
+				String userAccountExternalReferenceCode)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
 					accountExternalReferenceCode, accountRoleId,
-					accountUserExternalReferenceCode);
+					userAccountExternalReferenceCode);
 
 			String content = httpResponse.getContent();
 
@@ -329,7 +329,7 @@ public interface AccountRoleResource {
 		public HttpInvoker.HttpResponse
 				postAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
 					String accountExternalReferenceCode, Long accountRoleId,
-					String accountUserExternalReferenceCode)
+					String userAccountExternalReferenceCode)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -356,14 +356,14 @@ public interface AccountRoleResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/account-users/{accountUserExternalReferenceCode}");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/{userAccountExternalReferenceCode}");
 
 			httpInvoker.path(
 				"accountExternalReferenceCode", accountExternalReferenceCode);
 			httpInvoker.path("accountRoleId", accountRoleId);
 			httpInvoker.path(
-				"accountUserExternalReferenceCode",
-				accountUserExternalReferenceCode);
+				"userAccountExternalReferenceCode",
+				userAccountExternalReferenceCode);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -743,12 +743,12 @@ public interface AccountRoleResource {
 		}
 
 		public void deleteAccountRoleUserAssociation(
-				Long accountId, Long accountRoleId, Long accountUserId)
+				Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				deleteAccountRoleUserAssociationHttpResponse(
-					accountId, accountRoleId, accountUserId);
+					accountId, accountRoleId, userAccountId);
 
 			String content = httpResponse.getContent();
 
@@ -789,7 +789,7 @@ public interface AccountRoleResource {
 
 		public HttpInvoker.HttpResponse
 				deleteAccountRoleUserAssociationHttpResponse(
-					Long accountId, Long accountRoleId, Long accountUserId)
+					Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -816,11 +816,11 @@ public interface AccountRoleResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/{accountRoleId}/account-users/{accountUserId}");
+						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/{accountRoleId}/user-accounts/{userAccountId}");
 
 			httpInvoker.path("accountId", accountId);
 			httpInvoker.path("accountRoleId", accountRoleId);
-			httpInvoker.path("accountUserId", accountUserId);
+			httpInvoker.path("userAccountId", userAccountId);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -829,12 +829,12 @@ public interface AccountRoleResource {
 		}
 
 		public void postAccountRoleUserAssociation(
-				Long accountId, Long accountRoleId, Long accountUserId)
+				Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postAccountRoleUserAssociationHttpResponse(
-					accountId, accountRoleId, accountUserId);
+					accountId, accountRoleId, userAccountId);
 
 			String content = httpResponse.getContent();
 
@@ -875,7 +875,7 @@ public interface AccountRoleResource {
 
 		public HttpInvoker.HttpResponse
 				postAccountRoleUserAssociationHttpResponse(
-					Long accountId, Long accountRoleId, Long accountUserId)
+					Long accountId, Long accountRoleId, Long userAccountId)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -902,11 +902,11 @@ public interface AccountRoleResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/{accountRoleId}/account-users/{accountUserId}");
+						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/{accountRoleId}/user-accounts/{userAccountId}");
 
 			httpInvoker.path("accountId", accountId);
 			httpInvoker.path("accountRoleId", accountRoleId);
-			httpInvoker.path("accountUserId", accountUserId);
+			httpInvoker.path("userAccountId", userAccountId);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserAccountResource.java
@@ -42,109 +42,122 @@ public interface UserAccountResource {
 		return new Builder();
 	}
 
-	public Page<UserAccount> getAccountUsersByExternalReferenceCodePage(
+	public Page<UserAccount> getAccountUserAccountsByExternalReferenceCodePage(
 			String externalReferenceCode, String search, String filterString,
 			Pagination pagination, String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			getAccountUsersByExternalReferenceCodePageHttpResponse(
+			getAccountUserAccountsByExternalReferenceCodePageHttpResponse(
 				String externalReferenceCode, String search,
 				String filterString, Pagination pagination, String sortString)
 		throws Exception;
 
-	public UserAccount postAccountUserByExternalReferenceCode(
+	public UserAccount postAccountUserAccountByExternalReferenceCode(
 			String externalReferenceCode, UserAccount userAccount)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			postAccountUserByExternalReferenceCodeHttpResponse(
+			postAccountUserAccountByExternalReferenceCodeHttpResponse(
 				String externalReferenceCode, UserAccount userAccount)
 		throws Exception;
 
-	public void deleteAccountUsersByExternalReferenceCodeByEmailAddress(
+	public void deleteAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String[] strings)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			deleteAccountUsersByExternalReferenceCodeByEmailAddressHttpResponse(
+			deleteAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
 				String externalReferenceCode, String[] strings)
 		throws Exception;
 
-	public void postAccountUsersByExternalReferenceCodeByEmailAddress(
+	public void postAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String[] strings)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			postAccountUsersByExternalReferenceCodeByEmailAddressHttpResponse(
+			postAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
 				String externalReferenceCode, String[] strings)
 		throws Exception;
 
-	public void deleteAccountUserByExternalReferenceCodeByEmailAddress(
+	public void deleteAccountUserAccountByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String emailAddress)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			deleteAccountUserByExternalReferenceCodeByEmailAddressHttpResponse(
+			deleteAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
 				String externalReferenceCode, String emailAddress)
 		throws Exception;
 
-	public void postAccountUserByExternalReferenceCodeByEmailAddress(
+	public void postAccountUserAccountByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String emailAddress)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			postAccountUserByExternalReferenceCodeByEmailAddressHttpResponse(
+			postAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
 				String externalReferenceCode, String emailAddress)
 		throws Exception;
 
-	public Page<UserAccount> getAccountUsersPage(
+	public Page<UserAccount> getAccountUserAccountsPage(
 			Long accountId, String search, String filterString,
 			Pagination pagination, String sortString)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse getAccountUsersPageHttpResponse(
+	public HttpInvoker.HttpResponse getAccountUserAccountsPageHttpResponse(
 			Long accountId, String search, String filterString,
 			Pagination pagination, String sortString)
 		throws Exception;
 
-	public UserAccount postAccountUser(Long accountId, UserAccount userAccount)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse postAccountUserHttpResponse(
+	public UserAccount postAccountUserAccount(
 			Long accountId, UserAccount userAccount)
 		throws Exception;
 
-	public void deleteAccountUsersByEmailAddress(
+	public HttpInvoker.HttpResponse postAccountUserAccountHttpResponse(
+			Long accountId, UserAccount userAccount)
+		throws Exception;
+
+	public void postAccountUserAccountBatch(
+			Long accountId, String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postAccountUserAccountBatchHttpResponse(
+			Long accountId, String callbackURL, Object object)
+		throws Exception;
+
+	public void deleteAccountUserAccountsByEmailAddress(
 			Long accountId, String[] strings)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
-			deleteAccountUsersByEmailAddressHttpResponse(
+			deleteAccountUserAccountsByEmailAddressHttpResponse(
 				Long accountId, String[] strings)
 		throws Exception;
 
-	public void postAccountUsersByEmailAddress(Long accountId, String[] strings)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse postAccountUsersByEmailAddressHttpResponse(
+	public void postAccountUserAccountsByEmailAddress(
 			Long accountId, String[] strings)
 		throws Exception;
 
-	public void deleteAccountUserByEmailAddress(
+	public HttpInvoker.HttpResponse
+			postAccountUserAccountsByEmailAddressHttpResponse(
+				Long accountId, String[] strings)
+		throws Exception;
+
+	public void deleteAccountUserAccountByEmailAddress(
 			Long accountId, String emailAddress)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse deleteAccountUserByEmailAddressHttpResponse(
+	public HttpInvoker.HttpResponse
+			deleteAccountUserAccountByEmailAddressHttpResponse(
+				Long accountId, String emailAddress)
+		throws Exception;
+
+	public void postAccountUserAccountByEmailAddress(
 			Long accountId, String emailAddress)
 		throws Exception;
 
-	public void postAccountUserByEmailAddress(
-			Long accountId, String emailAddress)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse postAccountUserByEmailAddressHttpResponse(
-			Long accountId, String emailAddress)
+	public HttpInvoker.HttpResponse
+			postAccountUserAccountByEmailAddressHttpResponse(
+				Long accountId, String emailAddress)
 		throws Exception;
 
 	public UserAccount getMyUserAccount() throws Exception;
@@ -336,13 +349,15 @@ public interface UserAccountResource {
 
 	public static class UserAccountResourceImpl implements UserAccountResource {
 
-		public Page<UserAccount> getAccountUsersByExternalReferenceCodePage(
-				String externalReferenceCode, String search,
-				String filterString, Pagination pagination, String sortString)
+		public Page<UserAccount>
+				getAccountUserAccountsByExternalReferenceCodePage(
+					String externalReferenceCode, String search,
+					String filterString, Pagination pagination,
+					String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getAccountUsersByExternalReferenceCodePageHttpResponse(
+				getAccountUserAccountsByExternalReferenceCodePageHttpResponse(
 					externalReferenceCode, search, filterString, pagination,
 					sortString);
 
@@ -384,7 +399,7 @@ public interface UserAccountResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getAccountUsersByExternalReferenceCodePageHttpResponse(
+				getAccountUserAccountsByExternalReferenceCodePageHttpResponse(
 					String externalReferenceCode, String search,
 					String filterString, Pagination pagination,
 					String sortString)
@@ -433,7 +448,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -443,12 +458,12 @@ public interface UserAccountResource {
 			return httpInvoker.invoke();
 		}
 
-		public UserAccount postAccountUserByExternalReferenceCode(
+		public UserAccount postAccountUserAccountByExternalReferenceCode(
 				String externalReferenceCode, UserAccount userAccount)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postAccountUserByExternalReferenceCodeHttpResponse(
+				postAccountUserAccountByExternalReferenceCodeHttpResponse(
 					externalReferenceCode, userAccount);
 
 			String content = httpResponse.getContent();
@@ -489,7 +504,7 @@ public interface UserAccountResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAccountUserByExternalReferenceCodeHttpResponse(
+				postAccountUserAccountByExternalReferenceCodeHttpResponse(
 					String externalReferenceCode, UserAccount userAccount)
 			throws Exception {
 
@@ -519,7 +534,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -529,12 +544,13 @@ public interface UserAccountResource {
 			return httpInvoker.invoke();
 		}
 
-		public void deleteAccountUsersByExternalReferenceCodeByEmailAddress(
-				String externalReferenceCode, String[] strings)
+		public void
+				deleteAccountUserAccountsByExternalReferenceCodeByEmailAddress(
+					String externalReferenceCode, String[] strings)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				deleteAccountUsersByExternalReferenceCodeByEmailAddressHttpResponse(
+				deleteAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
 					externalReferenceCode, strings);
 
 			String content = httpResponse.getContent();
@@ -575,7 +591,7 @@ public interface UserAccountResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				deleteAccountUsersByExternalReferenceCodeByEmailAddressHttpResponse(
+				deleteAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
 					String externalReferenceCode, String[] strings)
 			throws Exception {
 
@@ -613,7 +629,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -623,12 +639,13 @@ public interface UserAccountResource {
 			return httpInvoker.invoke();
 		}
 
-		public void postAccountUsersByExternalReferenceCodeByEmailAddress(
-				String externalReferenceCode, String[] strings)
+		public void
+				postAccountUserAccountsByExternalReferenceCodeByEmailAddress(
+					String externalReferenceCode, String[] strings)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postAccountUsersByExternalReferenceCodeByEmailAddressHttpResponse(
+				postAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
 					externalReferenceCode, strings);
 
 			String content = httpResponse.getContent();
@@ -669,7 +686,7 @@ public interface UserAccountResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAccountUsersByExternalReferenceCodeByEmailAddressHttpResponse(
+				postAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
 					String externalReferenceCode, String[] strings)
 			throws Exception {
 
@@ -707,7 +724,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
@@ -717,12 +734,13 @@ public interface UserAccountResource {
 			return httpInvoker.invoke();
 		}
 
-		public void deleteAccountUserByExternalReferenceCodeByEmailAddress(
-				String externalReferenceCode, String emailAddress)
+		public void
+				deleteAccountUserAccountByExternalReferenceCodeByEmailAddress(
+					String externalReferenceCode, String emailAddress)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				deleteAccountUserByExternalReferenceCodeByEmailAddressHttpResponse(
+				deleteAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
 					externalReferenceCode, emailAddress);
 
 			String content = httpResponse.getContent();
@@ -763,7 +781,7 @@ public interface UserAccountResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				deleteAccountUserByExternalReferenceCodeByEmailAddressHttpResponse(
+				deleteAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
 					String externalReferenceCode, String emailAddress)
 			throws Exception {
 
@@ -791,7 +809,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address/{emailAddress}");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 			httpInvoker.path("emailAddress", emailAddress);
@@ -802,12 +820,12 @@ public interface UserAccountResource {
 			return httpInvoker.invoke();
 		}
 
-		public void postAccountUserByExternalReferenceCodeByEmailAddress(
+		public void postAccountUserAccountByExternalReferenceCodeByEmailAddress(
 				String externalReferenceCode, String emailAddress)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postAccountUserByExternalReferenceCodeByEmailAddressHttpResponse(
+				postAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
 					externalReferenceCode, emailAddress);
 
 			String content = httpResponse.getContent();
@@ -848,7 +866,7 @@ public interface UserAccountResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAccountUserByExternalReferenceCodeByEmailAddressHttpResponse(
+				postAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
 					String externalReferenceCode, String emailAddress)
 			throws Exception {
 
@@ -876,7 +894,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address/{emailAddress}");
+						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 			httpInvoker.path("emailAddress", emailAddress);
@@ -887,13 +905,13 @@ public interface UserAccountResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<UserAccount> getAccountUsersPage(
+		public Page<UserAccount> getAccountUserAccountsPage(
 				Long accountId, String search, String filterString,
 				Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getAccountUsersPageHttpResponse(
+				getAccountUserAccountsPageHttpResponse(
 					accountId, search, filterString, pagination, sortString);
 
 			String content = httpResponse.getContent();
@@ -933,7 +951,7 @@ public interface UserAccountResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse getAccountUsersPageHttpResponse(
+		public HttpInvoker.HttpResponse getAccountUserAccountsPageHttpResponse(
 				Long accountId, String search, String filterString,
 				Pagination pagination, String sortString)
 			throws Exception {
@@ -981,7 +999,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-users");
+						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts");
 
 			httpInvoker.path("accountId", accountId);
 
@@ -991,12 +1009,12 @@ public interface UserAccountResource {
 			return httpInvoker.invoke();
 		}
 
-		public UserAccount postAccountUser(
+		public UserAccount postAccountUserAccount(
 				Long accountId, UserAccount userAccount)
 			throws Exception {
 
-			HttpInvoker.HttpResponse httpResponse = postAccountUserHttpResponse(
-				accountId, userAccount);
+			HttpInvoker.HttpResponse httpResponse =
+				postAccountUserAccountHttpResponse(accountId, userAccount);
 
 			String content = httpResponse.getContent();
 
@@ -1035,7 +1053,7 @@ public interface UserAccountResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse postAccountUserHttpResponse(
+		public HttpInvoker.HttpResponse postAccountUserAccountHttpResponse(
 				Long accountId, UserAccount userAccount)
 			throws Exception {
 
@@ -1065,7 +1083,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-users");
+						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts");
 
 			httpInvoker.path("accountId", accountId);
 
@@ -1075,12 +1093,91 @@ public interface UserAccountResource {
 			return httpInvoker.invoke();
 		}
 
-		public void deleteAccountUsersByEmailAddress(
+		public void postAccountUserAccountBatch(
+				Long accountId, String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postAccountUserAccountBatchHttpResponse(
+					accountId, callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postAccountUserAccountBatchHttpResponse(
+				Long accountId, String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port +
+						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/batch");
+
+			httpInvoker.path("accountId", accountId);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void deleteAccountUserAccountsByEmailAddress(
 				Long accountId, String[] strings)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				deleteAccountUsersByEmailAddressHttpResponse(
+				deleteAccountUserAccountsByEmailAddressHttpResponse(
 					accountId, strings);
 
 			String content = httpResponse.getContent();
@@ -1121,7 +1218,7 @@ public interface UserAccountResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				deleteAccountUsersByEmailAddressHttpResponse(
+				deleteAccountUserAccountsByEmailAddressHttpResponse(
 					Long accountId, String[] strings)
 			throws Exception {
 
@@ -1159,7 +1256,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-users/by-email-address");
+						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address");
 
 			httpInvoker.path("accountId", accountId);
 
@@ -1169,12 +1266,13 @@ public interface UserAccountResource {
 			return httpInvoker.invoke();
 		}
 
-		public void postAccountUsersByEmailAddress(
+		public void postAccountUserAccountsByEmailAddress(
 				Long accountId, String[] strings)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postAccountUsersByEmailAddressHttpResponse(accountId, strings);
+				postAccountUserAccountsByEmailAddressHttpResponse(
+					accountId, strings);
 
 			String content = httpResponse.getContent();
 
@@ -1214,7 +1312,7 @@ public interface UserAccountResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAccountUsersByEmailAddressHttpResponse(
+				postAccountUserAccountsByEmailAddressHttpResponse(
 					Long accountId, String[] strings)
 			throws Exception {
 
@@ -1252,7 +1350,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-users/by-email-address");
+						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address");
 
 			httpInvoker.path("accountId", accountId);
 
@@ -1262,12 +1360,12 @@ public interface UserAccountResource {
 			return httpInvoker.invoke();
 		}
 
-		public void deleteAccountUserByEmailAddress(
+		public void deleteAccountUserAccountByEmailAddress(
 				Long accountId, String emailAddress)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				deleteAccountUserByEmailAddressHttpResponse(
+				deleteAccountUserAccountByEmailAddressHttpResponse(
 					accountId, emailAddress);
 
 			String content = httpResponse.getContent();
@@ -1308,7 +1406,7 @@ public interface UserAccountResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				deleteAccountUserByEmailAddressHttpResponse(
+				deleteAccountUserAccountByEmailAddressHttpResponse(
 					Long accountId, String emailAddress)
 			throws Exception {
 
@@ -1336,7 +1434,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-users/by-email-address/{emailAddress}");
+						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("accountId", accountId);
 			httpInvoker.path("emailAddress", emailAddress);
@@ -1347,12 +1445,12 @@ public interface UserAccountResource {
 			return httpInvoker.invoke();
 		}
 
-		public void postAccountUserByEmailAddress(
+		public void postAccountUserAccountByEmailAddress(
 				Long accountId, String emailAddress)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				postAccountUserByEmailAddressHttpResponse(
+				postAccountUserAccountByEmailAddressHttpResponse(
 					accountId, emailAddress);
 
 			String content = httpResponse.getContent();
@@ -1393,7 +1491,7 @@ public interface UserAccountResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				postAccountUserByEmailAddressHttpResponse(
+				postAccountUserAccountByEmailAddressHttpResponse(
 					Long accountId, String emailAddress)
 			throws Exception {
 
@@ -1421,7 +1519,7 @@ public interface UserAccountResource {
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port +
-						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-users/by-email-address/{emailAddress}");
+						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("accountId", accountId);
 			httpInvoker.path("emailAddress", emailAddress);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -975,7 +975,7 @@ paths:
             # @review
             description:
                 Unassigns account users to the account role
-            operationId: deleteAccountRoleUserAccountAssociationByExternalReferenceCode
+            operationId: deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode
             parameters:
                 - in: path
                   name: accountExternalReferenceCode
@@ -1005,7 +1005,7 @@ paths:
             # @review
             description:
                 Assigns account users to the account role
-            operationId: postAccountRoleUserAccountAssociationByExternalReferenceCode
+            operationId: postAccountAccountRoleUserAccountAssociationByExternalReferenceCode
             parameters:
                 - in: path
                   name: accountExternalReferenceCode
@@ -1143,7 +1143,7 @@ paths:
             # @review
             description:
                 Gets the account's roles
-            operationId: getAccountRolesByExternalReferenceCodePage
+            operationId: getAccountAccountRolesByExternalReferenceCodePage
             parameters:
                 - in: path
                   name: externalReferenceCode
@@ -1187,7 +1187,7 @@ paths:
             # @review
             description:
                 Adds a role for the account
-            operationId: postAccountRoleByExternalReferenceCode
+            operationId: postAccountAccountRoleByExternalReferenceCode
             parameters:
                 - in: path
                   name: externalReferenceCode
@@ -1534,7 +1534,7 @@ paths:
             # @review
             description:
                 Gets the account's roles
-            operationId: getAccountRolesPage
+            operationId: getAccountAccountRolesPage
             parameters:
                 - in: path
                   name: accountId
@@ -1579,7 +1579,7 @@ paths:
             # @review
             description:
                 Adds a role for the account
-            operationId: postAccountRole
+            operationId: postAccountAccountRole
             parameters:
                 - in: path
                   name: accountId
@@ -1613,7 +1613,7 @@ paths:
             # @review
             description:
                 Unassigns account users to the account role
-            operationId: deleteAccountRoleUserAccountAssociation
+            operationId: deleteAccountAccountRoleUserAccountAssociation
             parameters:
                 - in: path
                   name: accountId
@@ -1645,7 +1645,7 @@ paths:
             # @review
             description:
                 Assigns account users to the account role
-            operationId: postAccountRoleUserAccountAssociation
+            operationId: postAccountAccountRoleUserAccountAssociation
             parameters:
                 - in: path
                   name: accountId

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -975,7 +975,7 @@ paths:
             # @review
             description:
                 Unassigns account users to the account role
-            operationId: deleteAccountRoleUserAssociationByExternalReferenceCode
+            operationId: deleteAccountRoleUserAccountAssociationByExternalReferenceCode
             parameters:
                 - in: path
                   name: accountExternalReferenceCode
@@ -1005,7 +1005,7 @@ paths:
             # @review
             description:
                 Assigns account users to the account role
-            operationId: postAccountRoleUserAssociationByExternalReferenceCode
+            operationId: postAccountRoleUserAccountAssociationByExternalReferenceCode
             parameters:
                 - in: path
                   name: accountExternalReferenceCode
@@ -1613,7 +1613,7 @@ paths:
             # @review
             description:
                 Unassigns account users to the account role
-            operationId: deleteAccountRoleUserAssociation
+            operationId: deleteAccountRoleUserAccountAssociation
             parameters:
                 - in: path
                   name: accountId
@@ -1645,7 +1645,7 @@ paths:
             # @review
             description:
                 Assigns account users to the account role
-            operationId: postAccountRoleUserAssociation
+            operationId: postAccountRoleUserAccountAssociation
             parameters:
                 - in: path
                   name: accountId

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -970,7 +970,7 @@ paths:
                     description:
                         "Account successfully created"
             tags: ["Account"]
-    "/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/account-users/{accountUserExternalReferenceCode}":
+    "/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/{userAccountExternalReferenceCode}":
         delete:
             # @review
             description:
@@ -989,7 +989,7 @@ paths:
                       format: int64
                       type: integer
                 - in: path
-                  name: accountUserExternalReferenceCode
+                  name: userAccountExternalReferenceCode
                   required: true
                   schema:
                       type: string
@@ -1019,7 +1019,7 @@ paths:
                       format: int64
                       type: integer
                 - in: path
-                  name: accountUserExternalReferenceCode
+                  name: userAccountExternalReferenceCode
                   required: true
                   schema:
                       type: string
@@ -1215,12 +1215,12 @@ paths:
                     description:
                         ""
             tags: ["AccountRole"]
-    "/accounts/by-external-reference-code/{externalReferenceCode}/account-users":
+    "/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts":
         get:
             # @review
             description:
                 Gets the users assigned to an account
-            operationId: getAccountUsersByExternalReferenceCodePage
+            operationId: getAccountUserAccountsByExternalReferenceCodePage
             parameters:
                 - in: path
                   name: externalReferenceCode
@@ -1267,7 +1267,7 @@ paths:
             # @review
             description:
                 Creates a user and assigns them to the account
-            operationId: postAccountUserByExternalReferenceCode
+            operationId: postAccountUserAccountByExternalReferenceCode
             parameters:
                 - in: path
                   name: externalReferenceCode
@@ -1294,12 +1294,12 @@ paths:
                     description:
                         ""
             tags: ["UserAccount"]
-    "/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address":
+    "/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address":
         delete:
             # @review
             description:
                 Removes users from an account by their email addresses
-            operationId: deleteAccountUsersByExternalReferenceCodeByEmailAddress
+            operationId: deleteAccountUserAccountsByExternalReferenceCodeByEmailAddress
             parameters:
                 - in: path
                   name: externalReferenceCode
@@ -1336,7 +1336,7 @@ paths:
             # @review
             description:
                 Assigns users to an account by their email addresses
-            operationId: postAccountUsersByExternalReferenceCodeByEmailAddress
+            operationId: postAccountUserAccountsByExternalReferenceCodeByEmailAddress
             parameters:
                 - in: path
                   name: externalReferenceCode
@@ -1369,12 +1369,12 @@ paths:
                     description:
                         ""
             tags: ["UserAccount"]
-    "/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address/{emailAddress}":
+    "/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address/{emailAddress}":
         delete:
             # @review
             description:
                 Removes a user from an account by external reference code by their email address
-            operationId: deleteAccountUserByExternalReferenceCodeByEmailAddress
+            operationId: deleteAccountUserAccountByExternalReferenceCodeByEmailAddress
             parameters:
                 - in: path
                   name: externalReferenceCode
@@ -1398,7 +1398,7 @@ paths:
             # @review
             description:
                 Assigns a user to an account by external reference code by their email address
-            operationId: postAccountUserByExternalReferenceCodeByEmailAddress
+            operationId: postAccountUserAccountByExternalReferenceCodeByEmailAddress
             parameters:
                 - in: path
                   name: externalReferenceCode
@@ -1608,7 +1608,7 @@ paths:
                     description:
                         ""
             tags: ["AccountRole"]
-    "/accounts/{accountId}/account-roles/{accountRoleId}/account-users/{accountUserId}":
+    "/accounts/{accountId}/account-roles/{accountRoleId}/user-accounts/{userAccountId}":
         delete:
             # @review
             description:
@@ -1628,7 +1628,7 @@ paths:
                       format: int64
                       type: integer
                 - in: path
-                  name: accountUserId
+                  name: userAccountId
                   required: true
                   schema:
                       format: int64
@@ -1660,7 +1660,7 @@ paths:
                       format: int64
                       type: integer
                 - in: path
-                  name: accountUserId
+                  name: userAccountId
                   required: true
                   schema:
                       format: int64
@@ -1673,12 +1673,12 @@ paths:
                     description:
                         ""
             tags: ["AccountRole"]
-    "/accounts/{accountId}/account-users":
+    "/accounts/{accountId}/user-accounts":
         get:
             # @review
             description:
                 Gets the users assigned to an account
-            operationId: getAccountUsersPage
+            operationId: getAccountUserAccountsPage
             parameters:
                 - in: path
                   name: accountId
@@ -1726,7 +1726,7 @@ paths:
             # @review
             description:
                 Creates a user and assigns them to the account
-            operationId: postAccountUser
+            operationId: postAccountUserAccount
             parameters:
                 - in: path
                   name: accountId
@@ -1754,12 +1754,12 @@ paths:
                     description:
                         ""
             tags: ["UserAccount"]
-    "/accounts/{accountId}/account-users/by-email-address":
+    "/accounts/{accountId}/user-accounts/by-email-address":
         delete:
             # @review
             description:
                 Removes users from an account by their email addresses
-            operationId: deleteAccountUsersByEmailAddress
+            operationId: deleteAccountUserAccountsByEmailAddress
             parameters:
                 - in: path
                   name: accountId
@@ -1797,7 +1797,7 @@ paths:
             # @review
             description:
                 Assigns users to an account by their email addresses
-            operationId: postAccountUsersByEmailAddress
+            operationId: postAccountUserAccountsByEmailAddress
             parameters:
                 - in: path
                   name: accountId
@@ -1831,12 +1831,12 @@ paths:
                     description:
                         ""
             tags: ["UserAccount"]
-    "/accounts/{accountId}/account-users/by-email-address/{emailAddress}":
+    "/accounts/{accountId}/user-accounts/by-email-address/{emailAddress}":
         delete:
             # @review
             description:
                 Removes a user from an account by their email address
-            operationId: deleteAccountUserByEmailAddress
+            operationId: deleteAccountUserAccountByEmailAddress
             parameters:
                 - in: path
                   name: accountId
@@ -1861,7 +1861,7 @@ paths:
             # @review
             description:
                 Assigns a user to an account by their email address
-            operationId: postAccountUserByEmailAddress
+            operationId: postAccountUserAccountByEmailAddress
             parameters:
                 - in: path
                   name: accountId

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
@@ -338,7 +338,7 @@ public class Mutation {
 
 	@GraphQLField(description = "Unassigns account users to the account role")
 	public boolean
-			deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
+			deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
 				@GraphQLName("accountExternalReferenceCode") String
 					accountExternalReferenceCode,
 				@GraphQLName("accountRoleId") Long accountRoleId,
@@ -351,7 +351,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			accountRoleResource ->
 				accountRoleResource.
-					deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
+					deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
 						accountExternalReferenceCode, accountRoleId,
 						userAccountExternalReferenceCode));
 
@@ -360,7 +360,7 @@ public class Mutation {
 
 	@GraphQLField(description = "Assigns account users to the account role")
 	public boolean
-			createAccountRoleUserAccountAssociationByExternalReferenceCode(
+			createAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
 				@GraphQLName("accountExternalReferenceCode") String
 					accountExternalReferenceCode,
 				@GraphQLName("accountRoleId") Long accountRoleId,
@@ -373,7 +373,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			accountRoleResource ->
 				accountRoleResource.
-					postAccountRoleUserAccountAssociationByExternalReferenceCode(
+					postAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
 						accountExternalReferenceCode, accountRoleId,
 						userAccountExternalReferenceCode));
 
@@ -381,7 +381,7 @@ public class Mutation {
 	}
 
 	@GraphQLField(description = "Adds a role for the account")
-	public AccountRole createAccountRoleByExternalReferenceCode(
+	public AccountRole createAccountAccountRoleByExternalReferenceCode(
 			@GraphQLName("externalReferenceCode") String externalReferenceCode,
 			@GraphQLName("accountRole") AccountRole accountRole)
 		throws Exception {
@@ -390,12 +390,13 @@ public class Mutation {
 			_accountRoleResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			accountRoleResource ->
-				accountRoleResource.postAccountRoleByExternalReferenceCode(
-					externalReferenceCode, accountRole));
+				accountRoleResource.
+					postAccountAccountRoleByExternalReferenceCode(
+						externalReferenceCode, accountRole));
 	}
 
 	@GraphQLField(description = "Adds a role for the account")
-	public AccountRole createAccountRole(
+	public AccountRole createAccountAccountRole(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("accountRole") AccountRole accountRole)
 		throws Exception {
@@ -403,12 +404,27 @@ public class Mutation {
 		return _applyComponentServiceObjects(
 			_accountRoleResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			accountRoleResource -> accountRoleResource.postAccountRole(
+			accountRoleResource -> accountRoleResource.postAccountAccountRole(
 				accountId, accountRole));
 	}
 
+	@GraphQLField
+	public Response createAccountAccountRoleBatch(
+			@GraphQLName("accountId") Long accountId,
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("object") Object object)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_accountRoleResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			accountRoleResource ->
+				accountRoleResource.postAccountAccountRoleBatch(
+					accountId, callbackURL, object));
+	}
+
 	@GraphQLField(description = "Unassigns account users to the account role")
-	public boolean deleteAccountRoleUserAccountAssociation(
+	public boolean deleteAccountAccountRoleUserAccountAssociation(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("accountRoleId") Long accountRoleId,
 			@GraphQLName("userAccountId") Long userAccountId)
@@ -418,14 +434,15 @@ public class Mutation {
 			_accountRoleResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			accountRoleResource ->
-				accountRoleResource.deleteAccountRoleUserAccountAssociation(
-					accountId, accountRoleId, userAccountId));
+				accountRoleResource.
+					deleteAccountAccountRoleUserAccountAssociation(
+						accountId, accountRoleId, userAccountId));
 
 		return true;
 	}
 
 	@GraphQLField(description = "Assigns account users to the account role")
-	public boolean createAccountRoleUserAccountAssociation(
+	public boolean createAccountAccountRoleUserAccountAssociation(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("accountRoleId") Long accountRoleId,
 			@GraphQLName("userAccountId") Long userAccountId)
@@ -435,8 +452,9 @@ public class Mutation {
 			_accountRoleResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			accountRoleResource ->
-				accountRoleResource.postAccountRoleUserAccountAssociation(
-					accountId, accountRoleId, userAccountId));
+				accountRoleResource.
+					postAccountAccountRoleUserAccountAssociation(
+						accountId, accountRoleId, userAccountId));
 
 		return true;
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
@@ -337,12 +337,13 @@ public class Mutation {
 	}
 
 	@GraphQLField(description = "Unassigns account users to the account role")
-	public boolean deleteAccountRoleUserAssociationByExternalReferenceCode(
-			@GraphQLName("accountExternalReferenceCode") String
-				accountExternalReferenceCode,
-			@GraphQLName("accountRoleId") Long accountRoleId,
-			@GraphQLName("userAccountExternalReferenceCode") String
-				userAccountExternalReferenceCode)
+	public boolean
+			deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
+				@GraphQLName("accountExternalReferenceCode") String
+					accountExternalReferenceCode,
+				@GraphQLName("accountRoleId") Long accountRoleId,
+				@GraphQLName("userAccountExternalReferenceCode") String
+					userAccountExternalReferenceCode)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -350,7 +351,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			accountRoleResource ->
 				accountRoleResource.
-					deleteAccountRoleUserAssociationByExternalReferenceCode(
+					deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
 						accountExternalReferenceCode, accountRoleId,
 						userAccountExternalReferenceCode));
 
@@ -358,12 +359,13 @@ public class Mutation {
 	}
 
 	@GraphQLField(description = "Assigns account users to the account role")
-	public boolean createAccountRoleUserAssociationByExternalReferenceCode(
-			@GraphQLName("accountExternalReferenceCode") String
-				accountExternalReferenceCode,
-			@GraphQLName("accountRoleId") Long accountRoleId,
-			@GraphQLName("userAccountExternalReferenceCode") String
-				userAccountExternalReferenceCode)
+	public boolean
+			createAccountRoleUserAccountAssociationByExternalReferenceCode(
+				@GraphQLName("accountExternalReferenceCode") String
+					accountExternalReferenceCode,
+				@GraphQLName("accountRoleId") Long accountRoleId,
+				@GraphQLName("userAccountExternalReferenceCode") String
+					userAccountExternalReferenceCode)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -371,7 +373,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			accountRoleResource ->
 				accountRoleResource.
-					postAccountRoleUserAssociationByExternalReferenceCode(
+					postAccountRoleUserAccountAssociationByExternalReferenceCode(
 						accountExternalReferenceCode, accountRoleId,
 						userAccountExternalReferenceCode));
 
@@ -406,7 +408,7 @@ public class Mutation {
 	}
 
 	@GraphQLField(description = "Unassigns account users to the account role")
-	public boolean deleteAccountRoleUserAssociation(
+	public boolean deleteAccountRoleUserAccountAssociation(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("accountRoleId") Long accountRoleId,
 			@GraphQLName("userAccountId") Long userAccountId)
@@ -416,14 +418,14 @@ public class Mutation {
 			_accountRoleResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			accountRoleResource ->
-				accountRoleResource.deleteAccountRoleUserAssociation(
+				accountRoleResource.deleteAccountRoleUserAccountAssociation(
 					accountId, accountRoleId, userAccountId));
 
 		return true;
 	}
 
 	@GraphQLField(description = "Assigns account users to the account role")
-	public boolean createAccountRoleUserAssociation(
+	public boolean createAccountRoleUserAccountAssociation(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("accountRoleId") Long accountRoleId,
 			@GraphQLName("userAccountId") Long userAccountId)
@@ -433,7 +435,7 @@ public class Mutation {
 			_accountRoleResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			accountRoleResource ->
-				accountRoleResource.postAccountRoleUserAssociation(
+				accountRoleResource.postAccountRoleUserAccountAssociation(
 					accountId, accountRoleId, userAccountId));
 
 		return true;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
@@ -341,8 +341,8 @@ public class Mutation {
 			@GraphQLName("accountExternalReferenceCode") String
 				accountExternalReferenceCode,
 			@GraphQLName("accountRoleId") Long accountRoleId,
-			@GraphQLName("accountUserExternalReferenceCode") String
-				accountUserExternalReferenceCode)
+			@GraphQLName("userAccountExternalReferenceCode") String
+				userAccountExternalReferenceCode)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -352,7 +352,7 @@ public class Mutation {
 				accountRoleResource.
 					deleteAccountRoleUserAssociationByExternalReferenceCode(
 						accountExternalReferenceCode, accountRoleId,
-						accountUserExternalReferenceCode));
+						userAccountExternalReferenceCode));
 
 		return true;
 	}
@@ -362,8 +362,8 @@ public class Mutation {
 			@GraphQLName("accountExternalReferenceCode") String
 				accountExternalReferenceCode,
 			@GraphQLName("accountRoleId") Long accountRoleId,
-			@GraphQLName("accountUserExternalReferenceCode") String
-				accountUserExternalReferenceCode)
+			@GraphQLName("userAccountExternalReferenceCode") String
+				userAccountExternalReferenceCode)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -373,7 +373,7 @@ public class Mutation {
 				accountRoleResource.
 					postAccountRoleUserAssociationByExternalReferenceCode(
 						accountExternalReferenceCode, accountRoleId,
-						accountUserExternalReferenceCode));
+						userAccountExternalReferenceCode));
 
 		return true;
 	}
@@ -409,7 +409,7 @@ public class Mutation {
 	public boolean deleteAccountRoleUserAssociation(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("accountRoleId") Long accountRoleId,
-			@GraphQLName("accountUserId") Long accountUserId)
+			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -417,7 +417,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			accountRoleResource ->
 				accountRoleResource.deleteAccountRoleUserAssociation(
-					accountId, accountRoleId, accountUserId));
+					accountId, accountRoleId, userAccountId));
 
 		return true;
 	}
@@ -426,7 +426,7 @@ public class Mutation {
 	public boolean createAccountRoleUserAssociation(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("accountRoleId") Long accountRoleId,
-			@GraphQLName("accountUserId") Long accountUserId)
+			@GraphQLName("userAccountId") Long userAccountId)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -434,7 +434,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			accountRoleResource ->
 				accountRoleResource.postAccountRoleUserAssociation(
-					accountId, accountRoleId, accountUserId));
+					accountId, accountRoleId, userAccountId));
 
 		return true;
 	}
@@ -725,7 +725,7 @@ public class Mutation {
 	@GraphQLField(
 		description = "Creates a user and assigns them to the account"
 	)
-	public UserAccount createAccountUserByExternalReferenceCode(
+	public UserAccount createAccountUserAccountByExternalReferenceCode(
 			@GraphQLName("externalReferenceCode") String externalReferenceCode,
 			@GraphQLName("userAccount") UserAccount userAccount)
 		throws Exception {
@@ -734,16 +734,19 @@ public class Mutation {
 			_userAccountResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			userAccountResource ->
-				userAccountResource.postAccountUserByExternalReferenceCode(
-					externalReferenceCode, userAccount));
+				userAccountResource.
+					postAccountUserAccountByExternalReferenceCode(
+						externalReferenceCode, userAccount));
 	}
 
 	@GraphQLField(
 		description = "Removes users from an account by their email addresses"
 	)
-	public boolean deleteAccountUsersByExternalReferenceCodeByEmailAddress(
-			@GraphQLName("externalReferenceCode") String externalReferenceCode,
-			@GraphQLName("strings") String[] strings)
+	public boolean
+			deleteAccountUserAccountsByExternalReferenceCodeByEmailAddress(
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("strings") String[] strings)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -751,7 +754,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			userAccountResource ->
 				userAccountResource.
-					deleteAccountUsersByExternalReferenceCodeByEmailAddress(
+					deleteAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 						externalReferenceCode, strings));
 
 		return true;
@@ -760,9 +763,11 @@ public class Mutation {
 	@GraphQLField(
 		description = "Assigns users to an account by their email addresses"
 	)
-	public boolean createAccountUsersByExternalReferenceCodeByEmailAddress(
-			@GraphQLName("externalReferenceCode") String externalReferenceCode,
-			@GraphQLName("strings") String[] strings)
+	public boolean
+			createAccountUserAccountsByExternalReferenceCodeByEmailAddress(
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("strings") String[] strings)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -770,7 +775,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			userAccountResource ->
 				userAccountResource.
-					postAccountUsersByExternalReferenceCodeByEmailAddress(
+					postAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 						externalReferenceCode, strings));
 
 		return true;
@@ -779,9 +784,11 @@ public class Mutation {
 	@GraphQLField(
 		description = "Removes a user from an account by external reference code by their email address"
 	)
-	public boolean deleteAccountUserByExternalReferenceCodeByEmailAddress(
-			@GraphQLName("externalReferenceCode") String externalReferenceCode,
-			@GraphQLName("emailAddress") String emailAddress)
+	public boolean
+			deleteAccountUserAccountByExternalReferenceCodeByEmailAddress(
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("emailAddress") String emailAddress)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -789,7 +796,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			userAccountResource ->
 				userAccountResource.
-					deleteAccountUserByExternalReferenceCodeByEmailAddress(
+					deleteAccountUserAccountByExternalReferenceCodeByEmailAddress(
 						externalReferenceCode, emailAddress));
 
 		return true;
@@ -798,9 +805,11 @@ public class Mutation {
 	@GraphQLField(
 		description = "Assigns a user to an account by external reference code by their email address"
 	)
-	public boolean createAccountUserByExternalReferenceCodeByEmailAddress(
-			@GraphQLName("externalReferenceCode") String externalReferenceCode,
-			@GraphQLName("emailAddress") String emailAddress)
+	public boolean
+			createAccountUserAccountByExternalReferenceCodeByEmailAddress(
+				@GraphQLName("externalReferenceCode") String
+					externalReferenceCode,
+				@GraphQLName("emailAddress") String emailAddress)
 		throws Exception {
 
 		_applyVoidComponentServiceObjects(
@@ -808,7 +817,7 @@ public class Mutation {
 			this::_populateResourceContext,
 			userAccountResource ->
 				userAccountResource.
-					postAccountUserByExternalReferenceCodeByEmailAddress(
+					postAccountUserAccountByExternalReferenceCodeByEmailAddress(
 						externalReferenceCode, emailAddress));
 
 		return true;
@@ -817,7 +826,7 @@ public class Mutation {
 	@GraphQLField(
 		description = "Creates a user and assigns them to the account"
 	)
-	public UserAccount createAccountUser(
+	public UserAccount createAccountUserAccount(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("userAccount") UserAccount userAccount)
 		throws Exception {
@@ -825,14 +834,29 @@ public class Mutation {
 		return _applyComponentServiceObjects(
 			_userAccountResourceComponentServiceObjects,
 			this::_populateResourceContext,
-			userAccountResource -> userAccountResource.postAccountUser(
+			userAccountResource -> userAccountResource.postAccountUserAccount(
 				accountId, userAccount));
+	}
+
+	@GraphQLField
+	public Response createAccountUserAccountBatch(
+			@GraphQLName("accountId") Long accountId,
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("object") Object object)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_userAccountResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			userAccountResource ->
+				userAccountResource.postAccountUserAccountBatch(
+					accountId, callbackURL, object));
 	}
 
 	@GraphQLField(
 		description = "Removes users from an account by their email addresses"
 	)
-	public boolean deleteAccountUsersByEmailAddress(
+	public boolean deleteAccountUserAccountsByEmailAddress(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("strings") String[] strings)
 		throws Exception {
@@ -841,7 +865,7 @@ public class Mutation {
 			_userAccountResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			userAccountResource ->
-				userAccountResource.deleteAccountUsersByEmailAddress(
+				userAccountResource.deleteAccountUserAccountsByEmailAddress(
 					accountId, strings));
 
 		return true;
@@ -850,7 +874,7 @@ public class Mutation {
 	@GraphQLField(
 		description = "Assigns users to an account by their email addresses"
 	)
-	public boolean createAccountUsersByEmailAddress(
+	public boolean createAccountUserAccountsByEmailAddress(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("strings") String[] strings)
 		throws Exception {
@@ -859,7 +883,7 @@ public class Mutation {
 			_userAccountResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			userAccountResource ->
-				userAccountResource.postAccountUsersByEmailAddress(
+				userAccountResource.postAccountUserAccountsByEmailAddress(
 					accountId, strings));
 
 		return true;
@@ -868,7 +892,7 @@ public class Mutation {
 	@GraphQLField(
 		description = "Removes a user from an account by their email address"
 	)
-	public boolean deleteAccountUserByEmailAddress(
+	public boolean deleteAccountUserAccountByEmailAddress(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("emailAddress") String emailAddress)
 		throws Exception {
@@ -877,7 +901,7 @@ public class Mutation {
 			_userAccountResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			userAccountResource ->
-				userAccountResource.deleteAccountUserByEmailAddress(
+				userAccountResource.deleteAccountUserAccountByEmailAddress(
 					accountId, emailAddress));
 
 		return true;
@@ -886,7 +910,7 @@ public class Mutation {
 	@GraphQLField(
 		description = "Assigns a user to an account by their email address"
 	)
-	public boolean createAccountUserByEmailAddress(
+	public boolean createAccountUserAccountByEmailAddress(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("emailAddress") String emailAddress)
 		throws Exception {
@@ -895,7 +919,7 @@ public class Mutation {
 			_userAccountResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			userAccountResource ->
-				userAccountResource.postAccountUserByEmailAddress(
+				userAccountResource.postAccountUserAccountByEmailAddress(
 					accountId, emailAddress));
 
 		return true;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -241,10 +241,10 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {accountRolesByExternalReferenceCode(externalReferenceCode: ___, keywords: ___, page: ___, pageSize: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {accountAccountRolesByExternalReferenceCode(externalReferenceCode: ___, keywords: ___, page: ___, pageSize: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Gets the account's roles")
-	public AccountRolePage accountRolesByExternalReferenceCode(
+	public AccountRolePage accountAccountRolesByExternalReferenceCode(
 			@GraphQLName("externalReferenceCode") String externalReferenceCode,
 			@GraphQLName("keywords") String keywords,
 			@GraphQLName("pageSize") int pageSize,
@@ -256,19 +256,21 @@ public class Query {
 			_accountRoleResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			accountRoleResource -> new AccountRolePage(
-				accountRoleResource.getAccountRolesByExternalReferenceCodePage(
-					externalReferenceCode, keywords,
-					Pagination.of(page, pageSize),
-					_sortsBiFunction.apply(accountRoleResource, sortsString))));
+				accountRoleResource.
+					getAccountAccountRolesByExternalReferenceCodePage(
+						externalReferenceCode, keywords,
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(
+							accountRoleResource, sortsString))));
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {accountRoles(accountId: ___, keywords: ___, page: ___, pageSize: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {accountAccountRoles(accountId: ___, keywords: ___, page: ___, pageSize: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Gets the account's roles")
-	public AccountRolePage accountRoles(
+	public AccountRolePage accountAccountRoles(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("keywords") String keywords,
 			@GraphQLName("pageSize") int pageSize,
@@ -280,7 +282,7 @@ public class Query {
 			_accountRoleResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			accountRoleResource -> new AccountRolePage(
-				accountRoleResource.getAccountRolesPage(
+				accountRoleResource.getAccountAccountRolesPage(
 					accountId, keywords, Pagination.of(page, pageSize),
 					_sortsBiFunction.apply(accountRoleResource, sortsString))));
 	}
@@ -990,6 +992,36 @@ public class Query {
 
 	}
 
+	@GraphQLTypeExtension(Account.class)
+	public class GetAccountAccountRolesPageTypeExtension {
+
+		public GetAccountAccountRolesPageTypeExtension(Account account) {
+			_account = account;
+		}
+
+		@GraphQLField(description = "Gets the account's roles")
+		public AccountRolePage accountRoles(
+				@GraphQLName("keywords") String keywords,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_accountRoleResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				accountRoleResource -> new AccountRolePage(
+					accountRoleResource.getAccountAccountRolesPage(
+						_account.getId(), keywords,
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(
+							accountRoleResource, sortsString))));
+		}
+
+		private Account _account;
+
+	}
+
 	@GraphQLTypeExtension(Site.class)
 	public class GetSiteUserAccountsPageTypeExtension {
 
@@ -1078,6 +1110,40 @@ public class Query {
 		}
 
 		private AccountRole _accountRole;
+
+	}
+
+	@GraphQLTypeExtension(Account.class)
+	public class
+		GetAccountAccountRolesByExternalReferenceCodePageTypeExtension {
+
+		public GetAccountAccountRolesByExternalReferenceCodePageTypeExtension(
+			Account account) {
+
+			_account = account;
+		}
+
+		@GraphQLField(description = "Gets the account's roles")
+		public AccountRolePage accountRolesByExternalReferenceCode(
+				@GraphQLName("keywords") String keywords,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_accountRoleResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				accountRoleResource -> new AccountRolePage(
+					accountRoleResource.
+						getAccountAccountRolesByExternalReferenceCodePage(
+							_account.getExternalReferenceCode(), keywords,
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								accountRoleResource, sortsString))));
+		}
+
+		private Account _account;
 
 	}
 
@@ -1246,39 +1312,6 @@ public class Query {
 		}
 
 		private Organization _organization;
-
-	}
-
-	@GraphQLTypeExtension(Account.class)
-	public class GetAccountRolesByExternalReferenceCodePageTypeExtension {
-
-		public GetAccountRolesByExternalReferenceCodePageTypeExtension(
-			Account account) {
-
-			_account = account;
-		}
-
-		@GraphQLField(description = "Gets the account's roles")
-		public AccountRolePage rolesByExternalReferenceCode(
-				@GraphQLName("keywords") String keywords,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sort") String sortsString)
-			throws Exception {
-
-			return _applyComponentServiceObjects(
-				_accountRoleResourceComponentServiceObjects,
-				Query.this::_populateResourceContext,
-				accountRoleResource -> new AccountRolePage(
-					accountRoleResource.
-						getAccountRolesByExternalReferenceCodePage(
-							_account.getExternalReferenceCode(), keywords,
-							Pagination.of(page, pageSize),
-							_sortsBiFunction.apply(
-								accountRoleResource, sortsString))));
-		}
-
-		private Account _account;
 
 	}
 
@@ -1465,36 +1498,6 @@ public class Query {
 		}
 
 		private Organization _organization;
-
-	}
-
-	@GraphQLTypeExtension(Account.class)
-	public class GetAccountRolesPageTypeExtension {
-
-		public GetAccountRolesPageTypeExtension(Account account) {
-			_account = account;
-		}
-
-		@GraphQLField(description = "Gets the account's roles")
-		public AccountRolePage roles(
-				@GraphQLName("keywords") String keywords,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sort") String sortsString)
-			throws Exception {
-
-			return _applyComponentServiceObjects(
-				_accountRoleResourceComponentServiceObjects,
-				Query.this::_populateResourceContext,
-				accountRoleResource -> new AccountRolePage(
-					accountRoleResource.getAccountRolesPage(
-						_account.getId(), keywords,
-						Pagination.of(page, pageSize),
-						_sortsBiFunction.apply(
-							accountRoleResource, sortsString))));
-		}
-
-		private Account _account;
 
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -702,10 +702,10 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {accountUsersByExternalReferenceCode(externalReferenceCode: ___, filter: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {accountUserAccountsByExternalReferenceCode(externalReferenceCode: ___, filter: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Gets the users assigned to an account")
-	public UserAccountPage accountUsersByExternalReferenceCode(
+	public UserAccountPage accountUserAccountsByExternalReferenceCode(
 			@GraphQLName("externalReferenceCode") String externalReferenceCode,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") String filterString,
@@ -718,20 +718,23 @@ public class Query {
 			_userAccountResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			userAccountResource -> new UserAccountPage(
-				userAccountResource.getAccountUsersByExternalReferenceCodePage(
-					externalReferenceCode, search,
-					_filterBiFunction.apply(userAccountResource, filterString),
-					Pagination.of(page, pageSize),
-					_sortsBiFunction.apply(userAccountResource, sortsString))));
+				userAccountResource.
+					getAccountUserAccountsByExternalReferenceCodePage(
+						externalReferenceCode, search,
+						_filterBiFunction.apply(
+							userAccountResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(
+							userAccountResource, sortsString))));
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {accountUsers(accountId: ___, filter: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {accountUserAccounts(accountId: ___, filter: ___, page: ___, pageSize: ___, search: ___, sorts: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Gets the users assigned to an account")
-	public UserAccountPage accountUsers(
+	public UserAccountPage accountUserAccounts(
 			@GraphQLName("accountId") Long accountId,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") String filterString,
@@ -744,7 +747,7 @@ public class Query {
 			_userAccountResourceComponentServiceObjects,
 			this::_populateResourceContext,
 			userAccountResource -> new UserAccountPage(
-				userAccountResource.getAccountUsersPage(
+				userAccountResource.getAccountUserAccountsPage(
 					accountId, search,
 					_filterBiFunction.apply(userAccountResource, filterString),
 					Pagination.of(page, pageSize),
@@ -933,6 +936,39 @@ public class Query {
 			webUrlResource -> webUrlResource.getWebUrl(webUrlId));
 	}
 
+	@GraphQLTypeExtension(Account.class)
+	public class GetAccountUserAccountsPageTypeExtension {
+
+		public GetAccountUserAccountsPageTypeExtension(Account account) {
+			_account = account;
+		}
+
+		@GraphQLField(description = "Gets the users assigned to an account")
+		public UserAccountPage userAccounts(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_userAccountResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				userAccountResource -> new UserAccountPage(
+					userAccountResource.getAccountUserAccountsPage(
+						_account.getId(), search,
+						_filterBiFunction.apply(
+							userAccountResource, filterString),
+						Pagination.of(page, pageSize),
+						_sortsBiFunction.apply(
+							userAccountResource, sortsString))));
+		}
+
+		private Account _account;
+
+	}
+
 	@GraphQLTypeExtension(UserAccount.class)
 	public class GetUserAccountPhonesPageTypeExtension {
 
@@ -951,39 +987,6 @@ public class Query {
 		}
 
 		private UserAccount _userAccount;
-
-	}
-
-	@GraphQLTypeExtension(Account.class)
-	public class GetAccountUsersPageTypeExtension {
-
-		public GetAccountUsersPageTypeExtension(Account account) {
-			_account = account;
-		}
-
-		@GraphQLField(description = "Gets the users assigned to an account")
-		public UserAccountPage users(
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") String filterString,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sort") String sortsString)
-			throws Exception {
-
-			return _applyComponentServiceObjects(
-				_userAccountResourceComponentServiceObjects,
-				Query.this::_populateResourceContext,
-				userAccountResource -> new UserAccountPage(
-					userAccountResource.getAccountUsersPage(
-						_account.getId(), search,
-						_filterBiFunction.apply(
-							userAccountResource, filterString),
-						Pagination.of(page, pageSize),
-						_sortsBiFunction.apply(
-							userAccountResource, sortsString))));
-		}
-
-		private Account _account;
 
 	}
 
@@ -1019,6 +1022,43 @@ public class Query {
 		}
 
 		private Site _site;
+
+	}
+
+	@GraphQLTypeExtension(Account.class)
+	public class
+		GetAccountUserAccountsByExternalReferenceCodePageTypeExtension {
+
+		public GetAccountUserAccountsByExternalReferenceCodePageTypeExtension(
+			Account account) {
+
+			_account = account;
+		}
+
+		@GraphQLField(description = "Gets the users assigned to an account")
+		public UserAccountPage userAccountsByExternalReferenceCode(
+				@GraphQLName("search") String search,
+				@GraphQLName("filter") String filterString,
+				@GraphQLName("pageSize") int pageSize,
+				@GraphQLName("page") int page,
+				@GraphQLName("sort") String sortsString)
+			throws Exception {
+
+			return _applyComponentServiceObjects(
+				_userAccountResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				userAccountResource -> new UserAccountPage(
+					userAccountResource.
+						getAccountUserAccountsByExternalReferenceCodePage(
+							_account.getExternalReferenceCode(), search,
+							_filterBiFunction.apply(
+								userAccountResource, filterString),
+							Pagination.of(page, pageSize),
+							_sortsBiFunction.apply(
+								userAccountResource, sortsString))));
+		}
+
+		private Account _account;
 
 	}
 
@@ -1061,42 +1101,6 @@ public class Query {
 		}
 
 		private UserAccount _userAccount;
-
-	}
-
-	@GraphQLTypeExtension(Account.class)
-	public class GetAccountUsersByExternalReferenceCodePageTypeExtension {
-
-		public GetAccountUsersByExternalReferenceCodePageTypeExtension(
-			Account account) {
-
-			_account = account;
-		}
-
-		@GraphQLField(description = "Gets the users assigned to an account")
-		public UserAccountPage usersByExternalReferenceCode(
-				@GraphQLName("search") String search,
-				@GraphQLName("filter") String filterString,
-				@GraphQLName("pageSize") int pageSize,
-				@GraphQLName("page") int page,
-				@GraphQLName("sort") String sortsString)
-			throws Exception {
-
-			return _applyComponentServiceObjects(
-				_userAccountResourceComponentServiceObjects,
-				Query.this::_populateResourceContext,
-				userAccountResource -> new UserAccountPage(
-					userAccountResource.
-						getAccountUsersByExternalReferenceCodePage(
-							_account.getExternalReferenceCode(), search,
-							_filterBiFunction.apply(
-								userAccountResource, filterString),
-							Pagination.of(page, pageSize),
-							_sortsBiFunction.apply(
-								userAccountResource, sortsString))));
-		}
-
-		private Account _account;
 
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountRoleResourceImpl.java
@@ -49,17 +49,17 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 
 	@Override
 	public void deleteAccountRoleUserAssociation(
-			Long accountId, Long accountRoleId, Long accountUserId)
+			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception {
 
 		_accountRoleLocalService.unassociateUser(
-			accountId, accountRoleId, accountUserId);
+			accountId, accountRoleId, userAccountId);
 	}
 
 	@Override
 	public void deleteAccountRoleUserAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
-			String accountUserExternalReferenceCode)
+			String userAccountExternalReferenceCode)
 		throws Exception {
 
 		deleteAccountRoleUserAssociation(
@@ -67,7 +67,7 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 				accountExternalReferenceCode),
 			accountRoleId,
 			_userResourceDTOConverter.getUserId(
-				accountUserExternalReferenceCode));
+				userAccountExternalReferenceCode));
 	}
 
 	@Override
@@ -131,17 +131,17 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 
 	@Override
 	public void postAccountRoleUserAssociation(
-			Long accountId, Long accountRoleId, Long accountUserId)
+			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception {
 
 		_accountRoleLocalService.associateUser(
-			accountId, accountRoleId, accountUserId);
+			accountId, accountRoleId, userAccountId);
 	}
 
 	@Override
 	public void postAccountRoleUserAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
-			String accountUserExternalReferenceCode)
+			String userAccountExternalReferenceCode)
 		throws Exception {
 
 		postAccountRoleUserAssociation(
@@ -149,7 +149,7 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 				accountExternalReferenceCode),
 			accountRoleId,
 			_userResourceDTOConverter.getUserId(
-				accountUserExternalReferenceCode));
+				userAccountExternalReferenceCode));
 	}
 
 	private OrderByComparator<?> _getOrderByComparator(Sort[] sorts) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountRoleResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 
 	@Override
-	public void deleteAccountRoleUserAssociation(
+	public void deleteAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception {
 
@@ -57,12 +57,12 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 	}
 
 	@Override
-	public void deleteAccountRoleUserAssociationByExternalReferenceCode(
+	public void deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
 			String userAccountExternalReferenceCode)
 		throws Exception {
 
-		deleteAccountRoleUserAssociation(
+		deleteAccountRoleUserAccountAssociation(
 			_accountResourceDTOConverter.getAccountEntryId(
 				accountExternalReferenceCode),
 			accountRoleId,
@@ -130,7 +130,7 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 	}
 
 	@Override
-	public void postAccountRoleUserAssociation(
+	public void postAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception {
 
@@ -139,12 +139,12 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 	}
 
 	@Override
-	public void postAccountRoleUserAssociationByExternalReferenceCode(
+	public void postAccountRoleUserAccountAssociationByExternalReferenceCode(
 			String accountExternalReferenceCode, Long accountRoleId,
 			String userAccountExternalReferenceCode)
 		throws Exception {
 
-		postAccountRoleUserAssociation(
+		postAccountRoleUserAccountAssociation(
 			_accountResourceDTOConverter.getAccountEntryId(
 				accountExternalReferenceCode),
 			accountRoleId,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountRoleResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.ServiceScope;
 public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 
 	@Override
-	public void deleteAccountRoleUserAccountAssociation(
+	public void deleteAccountAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception {
 
@@ -57,12 +57,13 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 	}
 
 	@Override
-	public void deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
-			String accountExternalReferenceCode, Long accountRoleId,
-			String userAccountExternalReferenceCode)
+	public void
+			deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
+				String accountExternalReferenceCode, Long accountRoleId,
+				String userAccountExternalReferenceCode)
 		throws Exception {
 
-		deleteAccountRoleUserAccountAssociation(
+		deleteAccountAccountRoleUserAccountAssociation(
 			_accountResourceDTOConverter.getAccountEntryId(
 				accountExternalReferenceCode),
 			accountRoleId,
@@ -71,19 +72,19 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 	}
 
 	@Override
-	public Page<AccountRole> getAccountRolesByExternalReferenceCodePage(
+	public Page<AccountRole> getAccountAccountRolesByExternalReferenceCodePage(
 			String externalReferenceCode, String keywords,
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		return getAccountRolesPage(
+		return getAccountAccountRolesPage(
 			_accountResourceDTOConverter.getAccountEntryId(
 				externalReferenceCode),
 			keywords, pagination, sorts);
 	}
 
 	@Override
-	public Page<AccountRole> getAccountRolesPage(
+	public Page<AccountRole> getAccountAccountRolesPage(
 		Long accountId, String keywords, Pagination pagination, Sort[] sorts) {
 
 		BaseModelSearchResult<com.liferay.account.model.AccountRole>
@@ -104,7 +105,8 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 	}
 
 	@Override
-	public AccountRole postAccountRole(Long accountId, AccountRole accountRole)
+	public AccountRole postAccountAccountRole(
+			Long accountId, AccountRole accountRole)
 		throws Exception {
 
 		return _toAccountRole(
@@ -119,18 +121,18 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 	}
 
 	@Override
-	public AccountRole postAccountRoleByExternalReferenceCode(
+	public AccountRole postAccountAccountRoleByExternalReferenceCode(
 			String externalReferenceCode, AccountRole accountRole)
 		throws Exception {
 
-		return postAccountRole(
+		return postAccountAccountRole(
 			_accountResourceDTOConverter.getAccountEntryId(
 				externalReferenceCode),
 			accountRole);
 	}
 
 	@Override
-	public void postAccountRoleUserAccountAssociation(
+	public void postAccountAccountRoleUserAccountAssociation(
 			Long accountId, Long accountRoleId, Long userAccountId)
 		throws Exception {
 
@@ -139,12 +141,13 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 	}
 
 	@Override
-	public void postAccountRoleUserAccountAssociationByExternalReferenceCode(
-			String accountExternalReferenceCode, Long accountRoleId,
-			String userAccountExternalReferenceCode)
+	public void
+			postAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
+				String accountExternalReferenceCode, Long accountRoleId,
+				String userAccountExternalReferenceCode)
 		throws Exception {
 
-		postAccountRoleUserAccountAssociation(
+		postAccountAccountRoleUserAccountAssociation(
 			_accountResourceDTOConverter.getAccountEntryId(
 				accountExternalReferenceCode),
 			accountRoleId,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -104,7 +104,7 @@ public abstract class BaseAccountRoleResourceImpl
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public void deleteAccountRoleUserAssociationByExternalReferenceCode(
+	public void deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("accountExternalReferenceCode")
 			String accountExternalReferenceCode,
@@ -140,7 +140,7 @@ public abstract class BaseAccountRoleResourceImpl
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public void postAccountRoleUserAssociationByExternalReferenceCode(
+	public void postAccountRoleUserAccountAssociationByExternalReferenceCode(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("accountExternalReferenceCode")
 			String accountExternalReferenceCode,
@@ -286,7 +286,7 @@ public abstract class BaseAccountRoleResourceImpl
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public void deleteAccountRoleUserAssociation(
+	public void deleteAccountRoleUserAccountAssociation(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			@NotNull @Parameter(hidden = true) @PathParam("accountRoleId") Long
@@ -316,7 +316,7 @@ public abstract class BaseAccountRoleResourceImpl
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public void postAccountRoleUserAssociation(
+	public void postAccountRoleUserAccountAssociation(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			@NotNull @Parameter(hidden = true) @PathParam("accountRoleId") Long

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -83,7 +83,7 @@ public abstract class BaseAccountRoleResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/account-users/{accountUserExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/{userAccountExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@DELETE
 	@Operation(description = "Unassigns account users to the account role")
@@ -95,12 +95,12 @@ public abstract class BaseAccountRoleResourceImpl
 			),
 			@Parameter(in = ParameterIn.PATH, name = "accountRoleId"),
 			@Parameter(
-				in = ParameterIn.PATH, name = "accountUserExternalReferenceCode"
+				in = ParameterIn.PATH, name = "userAccountExternalReferenceCode"
 			)
 		}
 	)
 	@Path(
-		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/account-users/{accountUserExternalReferenceCode}"
+		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/{userAccountExternalReferenceCode}"
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
@@ -111,15 +111,15 @@ public abstract class BaseAccountRoleResourceImpl
 			@NotNull @Parameter(hidden = true) @PathParam("accountRoleId") Long
 				accountRoleId,
 			@NotNull @Parameter(hidden = true)
-			@PathParam("accountUserExternalReferenceCode")
-			String accountUserExternalReferenceCode)
+			@PathParam("userAccountExternalReferenceCode")
+			String userAccountExternalReferenceCode)
 		throws Exception {
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/account-users/{accountUserExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/{userAccountExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@Operation(description = "Assigns account users to the account role")
 	@Override
@@ -130,12 +130,12 @@ public abstract class BaseAccountRoleResourceImpl
 			),
 			@Parameter(in = ParameterIn.PATH, name = "accountRoleId"),
 			@Parameter(
-				in = ParameterIn.PATH, name = "accountUserExternalReferenceCode"
+				in = ParameterIn.PATH, name = "userAccountExternalReferenceCode"
 			)
 		}
 	)
 	@Path(
-		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/account-users/{accountUserExternalReferenceCode}"
+		"/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/{userAccountExternalReferenceCode}"
 	)
 	@POST
 	@Produces({"application/json", "application/xml"})
@@ -147,8 +147,8 @@ public abstract class BaseAccountRoleResourceImpl
 			@NotNull @Parameter(hidden = true) @PathParam("accountRoleId") Long
 				accountRoleId,
 			@NotNull @Parameter(hidden = true)
-			@PathParam("accountUserExternalReferenceCode")
-			String accountUserExternalReferenceCode)
+			@PathParam("userAccountExternalReferenceCode")
+			String userAccountExternalReferenceCode)
 		throws Exception {
 	}
 
@@ -269,7 +269,7 @@ public abstract class BaseAccountRoleResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/{accountRoleId}/account-users/{accountUserId}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/{accountRoleId}/user-accounts/{userAccountId}'  -u 'test@liferay.com:test'
 	 */
 	@DELETE
 	@Operation(description = "Unassigns account users to the account role")
@@ -278,11 +278,11 @@ public abstract class BaseAccountRoleResourceImpl
 		value = {
 			@Parameter(in = ParameterIn.PATH, name = "accountId"),
 			@Parameter(in = ParameterIn.PATH, name = "accountRoleId"),
-			@Parameter(in = ParameterIn.PATH, name = "accountUserId")
+			@Parameter(in = ParameterIn.PATH, name = "userAccountId")
 		}
 	)
 	@Path(
-		"/accounts/{accountId}/account-roles/{accountRoleId}/account-users/{accountUserId}"
+		"/accounts/{accountId}/account-roles/{accountRoleId}/user-accounts/{userAccountId}"
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
@@ -291,15 +291,15 @@ public abstract class BaseAccountRoleResourceImpl
 				accountId,
 			@NotNull @Parameter(hidden = true) @PathParam("accountRoleId") Long
 				accountRoleId,
-			@NotNull @Parameter(hidden = true) @PathParam("accountUserId") Long
-				accountUserId)
+			@NotNull @Parameter(hidden = true) @PathParam("userAccountId") Long
+				userAccountId)
 		throws Exception {
 	}
 
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/{accountRoleId}/account-users/{accountUserId}'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/{accountRoleId}/user-accounts/{userAccountId}'  -u 'test@liferay.com:test'
 	 */
 	@Operation(description = "Assigns account users to the account role")
 	@Override
@@ -307,11 +307,11 @@ public abstract class BaseAccountRoleResourceImpl
 		value = {
 			@Parameter(in = ParameterIn.PATH, name = "accountId"),
 			@Parameter(in = ParameterIn.PATH, name = "accountRoleId"),
-			@Parameter(in = ParameterIn.PATH, name = "accountUserId")
+			@Parameter(in = ParameterIn.PATH, name = "userAccountId")
 		}
 	)
 	@Path(
-		"/accounts/{accountId}/account-roles/{accountRoleId}/account-users/{accountUserId}"
+		"/accounts/{accountId}/account-roles/{accountRoleId}/user-accounts/{userAccountId}"
 	)
 	@POST
 	@Produces({"application/json", "application/xml"})
@@ -321,8 +321,8 @@ public abstract class BaseAccountRoleResourceImpl
 				accountId,
 			@NotNull @Parameter(hidden = true) @PathParam("accountRoleId") Long
 				accountRoleId,
-			@NotNull @Parameter(hidden = true) @PathParam("accountUserId") Long
-				accountUserId)
+			@NotNull @Parameter(hidden = true) @PathParam("userAccountId") Long
+				userAccountId)
 		throws Exception {
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -68,6 +68,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 /**
@@ -104,15 +105,16 @@ public abstract class BaseAccountRoleResourceImpl
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public void deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
-			@NotNull @Parameter(hidden = true)
-			@PathParam("accountExternalReferenceCode")
-			String accountExternalReferenceCode,
-			@NotNull @Parameter(hidden = true) @PathParam("accountRoleId") Long
-				accountRoleId,
-			@NotNull @Parameter(hidden = true)
-			@PathParam("userAccountExternalReferenceCode")
-			String userAccountExternalReferenceCode)
+	public void
+			deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("accountExternalReferenceCode")
+				String accountExternalReferenceCode,
+				@NotNull @Parameter(hidden = true) @PathParam("accountRoleId")
+					Long accountRoleId,
+				@NotNull @Parameter(hidden = true)
+				@PathParam("userAccountExternalReferenceCode")
+				String userAccountExternalReferenceCode)
 		throws Exception {
 	}
 
@@ -140,15 +142,16 @@ public abstract class BaseAccountRoleResourceImpl
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public void postAccountRoleUserAccountAssociationByExternalReferenceCode(
-			@NotNull @Parameter(hidden = true)
-			@PathParam("accountExternalReferenceCode")
-			String accountExternalReferenceCode,
-			@NotNull @Parameter(hidden = true) @PathParam("accountRoleId") Long
-				accountRoleId,
-			@NotNull @Parameter(hidden = true)
-			@PathParam("userAccountExternalReferenceCode")
-			String userAccountExternalReferenceCode)
+	public void
+			postAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
+				@NotNull @Parameter(hidden = true)
+				@PathParam("accountExternalReferenceCode")
+				String accountExternalReferenceCode,
+				@NotNull @Parameter(hidden = true) @PathParam("accountRoleId")
+					Long accountRoleId,
+				@NotNull @Parameter(hidden = true)
+				@PathParam("userAccountExternalReferenceCode")
+				String userAccountExternalReferenceCode)
 		throws Exception {
 	}
 
@@ -174,7 +177,7 @@ public abstract class BaseAccountRoleResourceImpl
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public Page<AccountRole> getAccountRolesByExternalReferenceCodePage(
+	public Page<AccountRole> getAccountAccountRolesByExternalReferenceCodePage(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode,
@@ -204,7 +207,7 @@ public abstract class BaseAccountRoleResourceImpl
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public AccountRole postAccountRoleByExternalReferenceCode(
+	public AccountRole postAccountAccountRoleByExternalReferenceCode(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode,
@@ -234,7 +237,7 @@ public abstract class BaseAccountRoleResourceImpl
 	@Path("/accounts/{accountId}/account-roles")
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public Page<AccountRole> getAccountRolesPage(
+	public Page<AccountRole> getAccountAccountRolesPage(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			@Parameter(hidden = true) @QueryParam("keywords") String keywords,
@@ -257,13 +260,54 @@ public abstract class BaseAccountRoleResourceImpl
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public AccountRole postAccountRole(
+	public AccountRole postAccountAccountRole(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			AccountRole accountRole)
 		throws Exception {
 
 		return new AccountRole();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/batch'  -u 'test@liferay.com:test'
+	 */
+	@Consumes("application/json")
+	@Override
+	@Parameters(
+		value = {
+			@Parameter(in = ParameterIn.PATH, name = "accountId"),
+			@Parameter(in = ParameterIn.QUERY, name = "callbackURL")
+		}
+	)
+	@Path("/accounts/{accountId}/account-roles/batch")
+	@POST
+	@Produces("application/json")
+	@Tags(value = {@Tag(name = "AccountRole")})
+	public Response postAccountAccountRoleBatch(
+			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
+				accountId,
+			@Parameter(hidden = true) @QueryParam("callbackURL") String
+				callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.postImportTask(
+				AccountRole.class.getName(), callbackURL, null, object)
+		).build();
 	}
 
 	/**
@@ -286,7 +330,7 @@ public abstract class BaseAccountRoleResourceImpl
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public void deleteAccountRoleUserAccountAssociation(
+	public void deleteAccountAccountRoleUserAccountAssociation(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			@NotNull @Parameter(hidden = true) @PathParam("accountRoleId") Long
@@ -316,7 +360,7 @@ public abstract class BaseAccountRoleResourceImpl
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "AccountRole")})
-	public void postAccountRoleUserAccountAssociation(
+	public void postAccountAccountRoleUserAccountAssociation(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			@NotNull @Parameter(hidden = true) @PathParam("accountRoleId") Long
@@ -332,6 +376,12 @@ public abstract class BaseAccountRoleResourceImpl
 			java.util.Collection<AccountRole> accountRoles,
 			Map<String, Serializable> parameters)
 		throws Exception {
+
+		for (AccountRole accountRole : accountRoles) {
+			postAccountAccountRole(
+				Long.parseLong((String)parameters.get("accountId")),
+				accountRole);
+		}
 	}
 
 	@Override
@@ -362,7 +412,9 @@ public abstract class BaseAccountRoleResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return null;
+		return getAccountAccountRolesPage(
+			Long.parseLong((String)parameters.get("accountId")),
+			(String)parameters.get("keywords"), pagination, sorts);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -86,7 +86,7 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts'  -u 'test@liferay.com:test'
 	 */
 	@GET
 	@Operation(description = "Gets the users assigned to an account")
@@ -102,11 +102,11 @@ public abstract class BaseUserAccountResourceImpl
 		}
 	)
 	@Path(
-		"/accounts/by-external-reference-code/{externalReferenceCode}/account-users"
+		"/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts"
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public Page<UserAccount> getAccountUsersByExternalReferenceCodePage(
+	public Page<UserAccount> getAccountUserAccountsByExternalReferenceCodePage(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode,
@@ -121,7 +121,7 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users' -d $'{"additionalName": ___, "alternateName": ___, "birthDate": ___, "customFields": ___, "emailAddress": ___, "familyName": ___, "givenName": ___, "honorificPrefix": ___, "honorificSuffix": ___, "jobTitle": ___, "userAccountContactInformation": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts' -d $'{"additionalName": ___, "alternateName": ___, "birthDate": ___, "customFields": ___, "emailAddress": ___, "familyName": ___, "givenName": ___, "honorificPrefix": ___, "honorificSuffix": ___, "jobTitle": ___, "userAccountContactInformation": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@Consumes({"application/json", "application/xml"})
 	@Operation(description = "Creates a user and assigns them to the account")
@@ -132,12 +132,12 @@ public abstract class BaseUserAccountResourceImpl
 		}
 	)
 	@Path(
-		"/accounts/by-external-reference-code/{externalReferenceCode}/account-users"
+		"/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts"
 	)
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public UserAccount postAccountUserByExternalReferenceCode(
+	public UserAccount postAccountUserAccountByExternalReferenceCode(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode,
@@ -150,7 +150,7 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address'  -u 'test@liferay.com:test'
 	 */
 	@Consumes({"application/json", "application/xml"})
 	@DELETE
@@ -164,11 +164,11 @@ public abstract class BaseUserAccountResourceImpl
 		}
 	)
 	@Path(
-		"/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address"
+		"/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address"
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public void deleteAccountUsersByExternalReferenceCodeByEmailAddress(
+	public void deleteAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode,
@@ -179,7 +179,7 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address'  -u 'test@liferay.com:test'
 	 */
 	@Consumes({"application/json", "application/xml"})
 	@Operation(
@@ -192,12 +192,12 @@ public abstract class BaseUserAccountResourceImpl
 		}
 	)
 	@Path(
-		"/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address"
+		"/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address"
 	)
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public void postAccountUsersByExternalReferenceCodeByEmailAddress(
+	public void postAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode,
@@ -208,7 +208,7 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address/{emailAddress}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address/{emailAddress}'  -u 'test@liferay.com:test'
 	 */
 	@DELETE
 	@Operation(
@@ -222,11 +222,11 @@ public abstract class BaseUserAccountResourceImpl
 		}
 	)
 	@Path(
-		"/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address/{emailAddress}"
+		"/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address/{emailAddress}"
 	)
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public void deleteAccountUserByExternalReferenceCodeByEmailAddress(
+	public void deleteAccountUserAccountByExternalReferenceCodeByEmailAddress(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode,
@@ -238,7 +238,7 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address/{emailAddress}'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address/{emailAddress}'  -u 'test@liferay.com:test'
 	 */
 	@Operation(
 		description = "Assigns a user to an account by external reference code by their email address"
@@ -251,12 +251,12 @@ public abstract class BaseUserAccountResourceImpl
 		}
 	)
 	@Path(
-		"/accounts/by-external-reference-code/{externalReferenceCode}/account-users/by-email-address/{emailAddress}"
+		"/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address/{emailAddress}"
 	)
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public void postAccountUserByExternalReferenceCodeByEmailAddress(
+	public void postAccountUserAccountByExternalReferenceCodeByEmailAddress(
 			@NotNull @Parameter(hidden = true)
 			@PathParam("externalReferenceCode")
 			String externalReferenceCode,
@@ -268,7 +268,7 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/account-users'  -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts'  -u 'test@liferay.com:test'
 	 */
 	@GET
 	@Operation(description = "Gets the users assigned to an account")
@@ -283,10 +283,10 @@ public abstract class BaseUserAccountResourceImpl
 			@Parameter(in = ParameterIn.QUERY, name = "sort")
 		}
 	)
-	@Path("/accounts/{accountId}/account-users")
+	@Path("/accounts/{accountId}/user-accounts")
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public Page<UserAccount> getAccountUsersPage(
+	public Page<UserAccount> getAccountUserAccountsPage(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			@Parameter(hidden = true) @QueryParam("search") String search,
@@ -300,17 +300,17 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/account-users' -d $'{"additionalName": ___, "alternateName": ___, "birthDate": ___, "customFields": ___, "emailAddress": ___, "familyName": ___, "givenName": ___, "honorificPrefix": ___, "honorificSuffix": ___, "jobTitle": ___, "userAccountContactInformation": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts' -d $'{"additionalName": ___, "alternateName": ___, "birthDate": ___, "customFields": ___, "emailAddress": ___, "familyName": ___, "givenName": ___, "honorificPrefix": ___, "honorificSuffix": ___, "jobTitle": ___, "userAccountContactInformation": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@Consumes({"application/json", "application/xml"})
 	@Operation(description = "Creates a user and assigns them to the account")
 	@Override
 	@Parameters(value = {@Parameter(in = ParameterIn.PATH, name = "accountId")})
-	@Path("/accounts/{accountId}/account-users")
+	@Path("/accounts/{accountId}/user-accounts")
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public UserAccount postAccountUser(
+	public UserAccount postAccountUserAccount(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			UserAccount userAccount)
@@ -322,7 +322,48 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/account-users/by-email-address'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/batch'  -u 'test@liferay.com:test'
+	 */
+	@Consumes("application/json")
+	@Override
+	@Parameters(
+		value = {
+			@Parameter(in = ParameterIn.PATH, name = "accountId"),
+			@Parameter(in = ParameterIn.QUERY, name = "callbackURL")
+		}
+	)
+	@Path("/accounts/{accountId}/user-accounts/batch")
+	@POST
+	@Produces("application/json")
+	@Tags(value = {@Tag(name = "UserAccount")})
+	public Response postAccountUserAccountBatch(
+			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
+				accountId,
+			@Parameter(hidden = true) @QueryParam("callbackURL") String
+				callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.postImportTask(
+				UserAccount.class.getName(), callbackURL, null, object)
+		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address'  -u 'test@liferay.com:test'
 	 */
 	@Consumes({"application/json", "application/xml"})
 	@DELETE
@@ -331,10 +372,10 @@ public abstract class BaseUserAccountResourceImpl
 	)
 	@Override
 	@Parameters(value = {@Parameter(in = ParameterIn.PATH, name = "accountId")})
-	@Path("/accounts/{accountId}/account-users/by-email-address")
+	@Path("/accounts/{accountId}/user-accounts/by-email-address")
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public void deleteAccountUsersByEmailAddress(
+	public void deleteAccountUserAccountsByEmailAddress(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			String[] strings)
@@ -344,7 +385,7 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/account-users/by-email-address'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address'  -u 'test@liferay.com:test'
 	 */
 	@Consumes({"application/json", "application/xml"})
 	@Operation(
@@ -352,11 +393,11 @@ public abstract class BaseUserAccountResourceImpl
 	)
 	@Override
 	@Parameters(value = {@Parameter(in = ParameterIn.PATH, name = "accountId")})
-	@Path("/accounts/{accountId}/account-users/by-email-address")
+	@Path("/accounts/{accountId}/user-accounts/by-email-address")
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public void postAccountUsersByEmailAddress(
+	public void postAccountUserAccountsByEmailAddress(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			String[] strings)
@@ -366,7 +407,7 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/account-users/by-email-address/{emailAddress}'  -u 'test@liferay.com:test'
+	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address/{emailAddress}'  -u 'test@liferay.com:test'
 	 */
 	@DELETE
 	@Operation(
@@ -379,10 +420,10 @@ public abstract class BaseUserAccountResourceImpl
 			@Parameter(in = ParameterIn.PATH, name = "emailAddress")
 		}
 	)
-	@Path("/accounts/{accountId}/account-users/by-email-address/{emailAddress}")
+	@Path("/accounts/{accountId}/user-accounts/by-email-address/{emailAddress}")
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public void deleteAccountUserByEmailAddress(
+	public void deleteAccountUserAccountByEmailAddress(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			@NotNull @Parameter(hidden = true) @PathParam("emailAddress") String
@@ -393,7 +434,7 @@ public abstract class BaseUserAccountResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/account-users/by-email-address/{emailAddress}'  -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address/{emailAddress}'  -u 'test@liferay.com:test'
 	 */
 	@Operation(
 		description = "Assigns a user to an account by their email address"
@@ -405,11 +446,11 @@ public abstract class BaseUserAccountResourceImpl
 			@Parameter(in = ParameterIn.PATH, name = "emailAddress")
 		}
 	)
-	@Path("/accounts/{accountId}/account-users/by-email-address/{emailAddress}")
+	@Path("/accounts/{accountId}/user-accounts/by-email-address/{emailAddress}")
 	@POST
 	@Produces({"application/json", "application/xml"})
 	@Tags(value = {@Tag(name = "UserAccount")})
-	public void postAccountUserByEmailAddress(
+	public void postAccountUserAccountByEmailAddress(
 			@NotNull @Parameter(hidden = true) @PathParam("accountId") Long
 				accountId,
 			@NotNull @Parameter(hidden = true) @PathParam("emailAddress") String
@@ -913,7 +954,9 @@ public abstract class BaseUserAccountResourceImpl
 		throws Exception {
 
 		for (UserAccount userAccount : userAccounts) {
-			postUserAccount(userAccount);
+			postAccountUserAccount(
+				Long.parseLong((String)parameters.get("accountId")),
+				userAccount);
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -107,7 +107,7 @@ public class UserAccountResourceImpl
 	extends BaseUserAccountResourceImpl implements EntityModelResource {
 
 	@Override
-	public void deleteAccountUserByEmailAddress(
+	public void deleteAccountUserAccountByEmailAddress(
 			Long accountId, String emailAddress)
 		throws Exception {
 
@@ -116,33 +116,33 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
-	public void deleteAccountUserByExternalReferenceCodeByEmailAddress(
+	public void deleteAccountUserAccountByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String emailAddress)
 		throws Exception {
 
-		deleteAccountUserByEmailAddress(
+		deleteAccountUserAccountByEmailAddress(
 			_accountResourceDTOConverter.getAccountEntryId(
 				externalReferenceCode),
 			emailAddress);
 	}
 
 	@Override
-	public void deleteAccountUsersByEmailAddress(
+	public void deleteAccountUserAccountsByEmailAddress(
 			Long accountId, String[] emailAddresses)
 		throws Exception {
 
 		for (String emailAddress : emailAddresses) {
-			deleteAccountUserByEmailAddress(accountId, emailAddress);
+			deleteAccountUserAccountByEmailAddress(accountId, emailAddress);
 		}
 	}
 
 	@Override
-	public void deleteAccountUsersByExternalReferenceCodeByEmailAddress(
+	public void deleteAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String[] emailAddresses)
 		throws Exception {
 
 		for (String emailAddress : emailAddresses) {
-			deleteAccountUserByExternalReferenceCodeByEmailAddress(
+			deleteAccountUserAccountByExternalReferenceCodeByEmailAddress(
 				externalReferenceCode, emailAddress);
 		}
 	}
@@ -164,19 +164,19 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
-	public Page<UserAccount> getAccountUsersByExternalReferenceCodePage(
+	public Page<UserAccount> getAccountUserAccountsByExternalReferenceCodePage(
 			String externalReferenceCode, String search, Filter filter,
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		return getAccountUsersPage(
+		return getAccountUserAccountsPage(
 			_accountResourceDTOConverter.getAccountEntryId(
 				externalReferenceCode),
 			search, filter, pagination, sorts);
 	}
 
 	@Override
-	public Page<UserAccount> getAccountUsersPage(
+	public Page<UserAccount> getAccountUserAccountsPage(
 			Long accountId, String search, Filter filter, Pagination pagination,
 			Sort[] sorts)
 		throws Exception {
@@ -301,7 +301,8 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
-	public UserAccount postAccountUser(Long accountId, UserAccount userAccount)
+	public UserAccount postAccountUserAccount(
+			Long accountId, UserAccount userAccount)
 		throws Exception {
 
 		userAccount = postUserAccount(userAccount);
@@ -317,7 +318,7 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
-	public void postAccountUserByEmailAddress(
+	public void postAccountUserAccountByEmailAddress(
 			Long accountId, String emailAddress)
 		throws Exception {
 
@@ -333,44 +334,44 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
-	public UserAccount postAccountUserByExternalReferenceCode(
+	public UserAccount postAccountUserAccountByExternalReferenceCode(
 			String externalReferenceCode, UserAccount userAccount)
 		throws Exception {
 
-		return postAccountUser(
+		return postAccountUserAccount(
 			_accountResourceDTOConverter.getAccountEntryId(
 				externalReferenceCode),
 			userAccount);
 	}
 
 	@Override
-	public void postAccountUserByExternalReferenceCodeByEmailAddress(
+	public void postAccountUserAccountByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String emailAddress)
 		throws Exception {
 
-		postAccountUserByEmailAddress(
+		postAccountUserAccountByEmailAddress(
 			_accountResourceDTOConverter.getAccountEntryId(
 				externalReferenceCode),
 			emailAddress);
 	}
 
 	@Override
-	public void postAccountUsersByEmailAddress(
+	public void postAccountUserAccountsByEmailAddress(
 			Long accountId, String[] emailAddresses)
 		throws Exception {
 
 		for (String emailAddress : emailAddresses) {
-			postAccountUserByEmailAddress(accountId, emailAddress);
+			postAccountUserAccountByEmailAddress(accountId, emailAddress);
 		}
 	}
 
 	@Override
-	public void postAccountUsersByExternalReferenceCodeByEmailAddress(
+	public void postAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 			String externalReferenceCode, String[] emailAddresses)
 		throws Exception {
 
 		for (String emailAddress : emailAddresses) {
-			postAccountUserByExternalReferenceCodeByEmailAddress(
+			postAccountUserAccountByExternalReferenceCodeByEmailAddress(
 				externalReferenceCode, emailAddress);
 		}
 	}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
@@ -286,7 +286,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 			_userAccountResource.putUserAccountByExternalReferenceCode(
 				RandomTestUtil.randomString(), _randomUserAccount());
 
-		_userAccountResource.postAccountUserByEmailAddress(
+		_userAccountResource.postAccountUserAccountByEmailAddress(
 			account.getId(), userAccount.getEmailAddress());
 
 		return userAccount;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
@@ -83,102 +83,107 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 
 	@Override
 	@Test
-	public void testDeleteAccountRoleUserAssociation() throws Exception {
+	public void testDeleteAccountRoleUserAccountAssociation() throws Exception {
 		AccountRole accountRole = _addAccountRole(_account);
 		UserAccount userAccount = _addAccountUserAccount(_account);
 
-		_assertAccountRoleUserAssociation(
+		_assertAccountRoleUserAccountAssociation(
 			_account, accountRole, userAccount, false);
 
 		_accountRoleLocalService.associateUser(
 			_account.getId(), accountRole.getId(), userAccount.getId());
 
-		_assertAccountRoleUserAssociation(
+		_assertAccountRoleUserAccountAssociation(
 			_account, accountRole, userAccount, true);
 
 		assertHttpResponseStatusCode(
 			204,
-			accountRoleResource.deleteAccountRoleUserAssociationHttpResponse(
-				_account.getId(), accountRole.getId(), userAccount.getId()));
+			accountRoleResource.
+				deleteAccountRoleUserAccountAssociationHttpResponse(
+					_account.getId(), accountRole.getId(),
+					userAccount.getId()));
 
-		_assertAccountRoleUserAssociation(
+		_assertAccountRoleUserAccountAssociation(
 			_account, accountRole, userAccount, false);
 	}
 
 	@Override
 	@Test
-	public void testDeleteAccountRoleUserAssociationByExternalReferenceCode()
+	public void testDeleteAccountRoleUserAccountAssociationByExternalReferenceCode()
 		throws Exception {
 
 		AccountRole accountRole = _addAccountRole(_account);
 		UserAccount userAccount = _addAccountUserAccount(_account);
 
-		_assertAccountRoleUserAssociation(
+		_assertAccountRoleUserAccountAssociation(
 			_account, accountRole, userAccount, false);
 
 		_accountRoleLocalService.associateUser(
 			_account.getId(), accountRole.getId(), userAccount.getId());
 
-		_assertAccountRoleUserAssociation(
+		_assertAccountRoleUserAccountAssociation(
 			_account, accountRole, userAccount, true);
 
 		accountRoleResource.
-			deleteAccountRoleUserAssociationByExternalReferenceCode(
+			deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
 				_account.getExternalReferenceCode(), accountRole.getId(),
 				userAccount.getExternalReferenceCode());
 
-		_assertAccountRoleUserAssociation(
+		_assertAccountRoleUserAccountAssociation(
 			_account, accountRole, userAccount, false);
 	}
 
 	@Override
 	@Test
-	public void testPostAccountRoleUserAssociation() throws Exception {
+	public void testPostAccountRoleUserAccountAssociation() throws Exception {
 		AccountRole accountRole = _addAccountRole(_account);
 		UserAccount userAccount = _addAccountUserAccount(_account);
 
-		_assertAccountRoleUserAssociation(
+		_assertAccountRoleUserAccountAssociation(
 			_account, accountRole, userAccount, false);
 
 		assertHttpResponseStatusCode(
 			204,
-			accountRoleResource.postAccountRoleUserAssociationHttpResponse(
-				_account.getId(), accountRole.getId(), userAccount.getId()));
+			accountRoleResource.
+				postAccountRoleUserAccountAssociationHttpResponse(
+					_account.getId(), accountRole.getId(),
+					userAccount.getId()));
 
-		_assertAccountRoleUserAssociation(
+		_assertAccountRoleUserAccountAssociation(
 			_account, accountRole, userAccount, true);
 
 		assertHttpResponseStatusCode(
 			404,
-			accountRoleResource.postAccountRoleUserAssociationHttpResponse(
-				_account.getId(), 0L, userAccount.getId()));
+			accountRoleResource.
+				postAccountRoleUserAccountAssociationHttpResponse(
+					_account.getId(), 0L, userAccount.getId()));
 	}
 
 	@Override
 	@Test
-	public void testPostAccountRoleUserAssociationByExternalReferenceCode()
+	public void testPostAccountRoleUserAccountAssociationByExternalReferenceCode()
 		throws Exception {
 
 		AccountRole accountRole = _addAccountRole(_account);
 		UserAccount userAccount = _addAccountUserAccount(_account);
 
-		_assertAccountRoleUserAssociation(
+		_assertAccountRoleUserAccountAssociation(
 			_account, accountRole, userAccount, false);
 
 		assertHttpResponseStatusCode(
 			204,
 			accountRoleResource.
-				postAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
+				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					_account.getExternalReferenceCode(), accountRole.getId(),
 					userAccount.getExternalReferenceCode()));
 
-		_assertAccountRoleUserAssociation(
+		_assertAccountRoleUserAccountAssociation(
 			_account, accountRole, userAccount, true);
 
 		assertHttpResponseStatusCode(
 			404,
 			accountRoleResource.
-				postAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
+				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					_account.getExternalReferenceCode(), 0L,
 					userAccount.getExternalReferenceCode()));
 	}
@@ -189,7 +194,8 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 	}
 
 	@Override
-	protected AccountRole testDeleteAccountRoleUserAssociation_addAccountRole()
+	protected AccountRole
+			testDeleteAccountRoleUserAccountAssociation_addAccountRole()
 		throws Exception {
 
 		return _addAccountRole(_account);
@@ -197,7 +203,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 
 	@Override
 	protected AccountRole
-			testDeleteAccountRoleUserAssociationByExternalReferenceCode_addAccountRole()
+			testDeleteAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
 		throws Exception {
 
 		return _addAccountRole(_account);
@@ -262,7 +268,8 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 	}
 
 	@Override
-	protected AccountRole testPostAccountRoleUserAssociation_addAccountRole()
+	protected AccountRole
+			testPostAccountRoleUserAccountAssociation_addAccountRole()
 		throws Exception {
 
 		return _addAccountRole(_account);
@@ -270,7 +277,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 
 	@Override
 	protected AccountRole
-			testPostAccountRoleUserAssociationByExternalReferenceCode_addAccountRole()
+			testPostAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
 		throws Exception {
 
 		return _addAccountRole(_account);
@@ -294,7 +301,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 		return userAccount;
 	}
 
-	private void _assertAccountRoleUserAssociation(
+	private void _assertAccountRoleUserAccountAssociation(
 			Account account, AccountRole accountRole, UserAccount userAccount,
 			boolean hasAssociation)
 		throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
@@ -85,7 +85,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 	@Test
 	public void testDeleteAccountRoleUserAssociation() throws Exception {
 		AccountRole accountRole = _addAccountRole(_account);
-		UserAccount userAccount = _addUserAccount(_account);
+		UserAccount userAccount = _addAccountUserAccount(_account);
 
 		_assertAccountRoleUserAssociation(
 			_account, accountRole, userAccount, false);
@@ -111,7 +111,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 		throws Exception {
 
 		AccountRole accountRole = _addAccountRole(_account);
-		UserAccount userAccount = _addUserAccount(_account);
+		UserAccount userAccount = _addAccountUserAccount(_account);
 
 		_assertAccountRoleUserAssociation(
 			_account, accountRole, userAccount, false);
@@ -135,7 +135,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 	@Test
 	public void testPostAccountRoleUserAssociation() throws Exception {
 		AccountRole accountRole = _addAccountRole(_account);
-		UserAccount userAccount = _addUserAccount(_account);
+		UserAccount userAccount = _addAccountUserAccount(_account);
 
 		_assertAccountRoleUserAssociation(
 			_account, accountRole, userAccount, false);
@@ -160,7 +160,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 		throws Exception {
 
 		AccountRole accountRole = _addAccountRole(_account);
-		UserAccount userAccount = _addUserAccount(_account);
+		UserAccount userAccount = _addAccountUserAccount(_account);
 
 		_assertAccountRoleUserAssociation(
 			_account, accountRole, userAccount, false);
@@ -281,7 +281,9 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 			account.getId(), randomAccountRole());
 	}
 
-	private UserAccount _addUserAccount(Account account) throws Exception {
+	private UserAccount _addAccountUserAccount(Account account)
+		throws Exception {
+
 		UserAccount userAccount =
 			_userAccountResource.putUserAccountByExternalReferenceCode(
 				RandomTestUtil.randomString(), _randomUserAccount());

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
@@ -83,8 +83,10 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 
 	@Override
 	@Test
-	public void testDeleteAccountRoleUserAccountAssociation() throws Exception {
-		AccountRole accountRole = _addAccountRole(_account);
+	public void testDeleteAccountAccountRoleUserAccountAssociation()
+		throws Exception {
+
+		AccountRole accountRole = _addAccountAccountRole(_account);
 		UserAccount userAccount = _addAccountUserAccount(_account);
 
 		_assertAccountRoleUserAccountAssociation(
@@ -99,7 +101,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			accountRoleResource.
-				deleteAccountRoleUserAccountAssociationHttpResponse(
+				deleteAccountAccountRoleUserAccountAssociationHttpResponse(
 					_account.getId(), accountRole.getId(),
 					userAccount.getId()));
 
@@ -109,10 +111,10 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 
 	@Override
 	@Test
-	public void testDeleteAccountRoleUserAccountAssociationByExternalReferenceCode()
+	public void testDeleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode()
 		throws Exception {
 
-		AccountRole accountRole = _addAccountRole(_account);
+		AccountRole accountRole = _addAccountAccountRole(_account);
 		UserAccount userAccount = _addAccountUserAccount(_account);
 
 		_assertAccountRoleUserAccountAssociation(
@@ -125,7 +127,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 			_account, accountRole, userAccount, true);
 
 		accountRoleResource.
-			deleteAccountRoleUserAccountAssociationByExternalReferenceCode(
+			deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode(
 				_account.getExternalReferenceCode(), accountRole.getId(),
 				userAccount.getExternalReferenceCode());
 
@@ -135,8 +137,10 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 
 	@Override
 	@Test
-	public void testPostAccountRoleUserAccountAssociation() throws Exception {
-		AccountRole accountRole = _addAccountRole(_account);
+	public void testPostAccountAccountRoleUserAccountAssociation()
+		throws Exception {
+
+		AccountRole accountRole = _addAccountAccountRole(_account);
 		UserAccount userAccount = _addAccountUserAccount(_account);
 
 		_assertAccountRoleUserAccountAssociation(
@@ -145,7 +149,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			accountRoleResource.
-				postAccountRoleUserAccountAssociationHttpResponse(
+				postAccountAccountRoleUserAccountAssociationHttpResponse(
 					_account.getId(), accountRole.getId(),
 					userAccount.getId()));
 
@@ -155,16 +159,16 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			accountRoleResource.
-				postAccountRoleUserAccountAssociationHttpResponse(
+				postAccountAccountRoleUserAccountAssociationHttpResponse(
 					_account.getId(), 0L, userAccount.getId()));
 	}
 
 	@Override
 	@Test
-	public void testPostAccountRoleUserAccountAssociationByExternalReferenceCode()
+	public void testPostAccountAccountRoleUserAccountAssociationByExternalReferenceCode()
 		throws Exception {
 
-		AccountRole accountRole = _addAccountRole(_account);
+		AccountRole accountRole = _addAccountAccountRole(_account);
 		UserAccount userAccount = _addAccountUserAccount(_account);
 
 		_assertAccountRoleUserAccountAssociation(
@@ -173,7 +177,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			accountRoleResource.
-				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+				postAccountAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					_account.getExternalReferenceCode(), accountRole.getId(),
 					userAccount.getExternalReferenceCode()));
 
@@ -183,7 +187,7 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 		assertHttpResponseStatusCode(
 			404,
 			accountRoleResource.
-				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+				postAccountAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					_account.getExternalReferenceCode(), 0L,
 					userAccount.getExternalReferenceCode()));
 	}
@@ -195,48 +199,50 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 
 	@Override
 	protected AccountRole
-			testDeleteAccountRoleUserAccountAssociation_addAccountRole()
+			testDeleteAccountAccountRoleUserAccountAssociation_addAccountRole()
 		throws Exception {
 
-		return _addAccountRole(_account);
+		return _addAccountAccountRole(_account);
 	}
 
 	@Override
 	protected AccountRole
-			testDeleteAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
+			testDeleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
 		throws Exception {
 
-		return _addAccountRole(_account);
+		return _addAccountAccountRole(_account);
 	}
 
 	@Override
 	protected AccountRole
-			testGetAccountRolesByExternalReferenceCodePage_addAccountRole(
+			testGetAccountAccountRolesByExternalReferenceCodePage_addAccountRole(
 				String externalReferenceCode, AccountRole accountRole)
 		throws Exception {
 
-		return accountRoleResource.postAccountRoleByExternalReferenceCode(
-			externalReferenceCode, accountRole);
+		return accountRoleResource.
+			postAccountAccountRoleByExternalReferenceCode(
+				externalReferenceCode, accountRole);
 	}
 
 	@Override
 	protected String
-			testGetAccountRolesByExternalReferenceCodePage_getExternalReferenceCode()
+			testGetAccountAccountRolesByExternalReferenceCodePage_getExternalReferenceCode()
 		throws Exception {
 
 		return _account.getExternalReferenceCode();
 	}
 
 	@Override
-	protected AccountRole testGetAccountRolesPage_addAccountRole(
+	protected AccountRole testGetAccountAccountRolesPage_addAccountRole(
 			Long accountId, AccountRole accountRole)
 		throws Exception {
 
-		return accountRoleResource.postAccountRole(accountId, accountRole);
+		return accountRoleResource.postAccountAccountRole(
+			accountId, accountRole);
 	}
 
 	@Override
-	protected Long testGetAccountRolesPage_getAccountId() {
+	protected Long testGetAccountAccountRolesPage_getAccountId() {
 		return _account.getId();
 	}
 
@@ -244,47 +250,50 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 	protected AccountRole testGraphQLAccountRole_addAccountRole()
 		throws Exception {
 
-		return accountRoleResource.postAccountRole(
+		return accountRoleResource.postAccountAccountRole(
 			_account.getId(), randomAccountRole());
 	}
 
 	@Override
-	protected AccountRole testPostAccountRole_addAccountRole(
+	protected AccountRole testPostAccountAccountRole_addAccountRole(
 			AccountRole accountRole)
 		throws Exception {
 
-		return accountRoleResource.postAccountRole(
+		return accountRoleResource.postAccountAccountRole(
 			_account.getId(), accountRole);
 	}
 
 	@Override
 	protected AccountRole
-			testPostAccountRoleByExternalReferenceCode_addAccountRole(
+			testPostAccountAccountRoleByExternalReferenceCode_addAccountRole(
 				AccountRole accountRole)
 		throws Exception {
 
-		return accountRoleResource.postAccountRoleByExternalReferenceCode(
-			_account.getExternalReferenceCode(), accountRole);
+		return accountRoleResource.
+			postAccountAccountRoleByExternalReferenceCode(
+				_account.getExternalReferenceCode(), accountRole);
 	}
 
 	@Override
 	protected AccountRole
-			testPostAccountRoleUserAccountAssociation_addAccountRole()
+			testPostAccountAccountRoleUserAccountAssociation_addAccountRole()
 		throws Exception {
 
-		return _addAccountRole(_account);
+		return _addAccountAccountRole(_account);
 	}
 
 	@Override
 	protected AccountRole
-			testPostAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
+			testPostAccountAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
 		throws Exception {
 
-		return _addAccountRole(_account);
+		return _addAccountAccountRole(_account);
 	}
 
-	private AccountRole _addAccountRole(Account account) throws Exception {
-		return accountRoleResource.postAccountRole(
+	private AccountRole _addAccountAccountRole(Account account)
+		throws Exception {
+
+		return accountRoleResource.postAccountAccountRole(
 			account.getId(), randomAccountRole());
 	}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -202,22 +202,22 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteAccountRoleUserAssociationByExternalReferenceCode()
+	public void testDeleteAccountRoleUserAccountAssociationByExternalReferenceCode()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		AccountRole accountRole =
-			testDeleteAccountRoleUserAssociationByExternalReferenceCode_addAccountRole();
+			testDeleteAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole();
 
 		assertHttpResponseStatusCode(
 			204,
 			accountRoleResource.
-				deleteAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
+				deleteAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					null, accountRole.getId(), null));
 	}
 
 	protected AccountRole
-			testDeleteAccountRoleUserAssociationByExternalReferenceCode_addAccountRole()
+			testDeleteAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -225,28 +225,28 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testPostAccountRoleUserAssociationByExternalReferenceCode()
+	public void testPostAccountRoleUserAccountAssociationByExternalReferenceCode()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		AccountRole accountRole =
-			testPostAccountRoleUserAssociationByExternalReferenceCode_addAccountRole();
+			testPostAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole();
 
 		assertHttpResponseStatusCode(
 			204,
 			accountRoleResource.
-				postAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
+				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					null, accountRole.getId(), null));
 
 		assertHttpResponseStatusCode(
 			404,
 			accountRoleResource.
-				postAccountRoleUserAssociationByExternalReferenceCodeHttpResponse(
+				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					null, 0L, null));
 	}
 
 	protected AccountRole
-			testPostAccountRoleUserAssociationByExternalReferenceCode_addAccountRole()
+			testPostAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -806,18 +806,20 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteAccountRoleUserAssociation() throws Exception {
+	public void testDeleteAccountRoleUserAccountAssociation() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		AccountRole accountRole =
-			testDeleteAccountRoleUserAssociation_addAccountRole();
+			testDeleteAccountRoleUserAccountAssociation_addAccountRole();
 
 		assertHttpResponseStatusCode(
 			204,
-			accountRoleResource.deleteAccountRoleUserAssociationHttpResponse(
-				accountRole.getAccountId(), accountRole.getId(), null));
+			accountRoleResource.
+				deleteAccountRoleUserAccountAssociationHttpResponse(
+					accountRole.getAccountId(), accountRole.getId(), null));
 	}
 
-	protected AccountRole testDeleteAccountRoleUserAssociation_addAccountRole()
+	protected AccountRole
+			testDeleteAccountRoleUserAccountAssociation_addAccountRole()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -825,23 +827,26 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testPostAccountRoleUserAssociation() throws Exception {
+	public void testPostAccountRoleUserAccountAssociation() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		AccountRole accountRole =
-			testPostAccountRoleUserAssociation_addAccountRole();
+			testPostAccountRoleUserAccountAssociation_addAccountRole();
 
 		assertHttpResponseStatusCode(
 			204,
-			accountRoleResource.postAccountRoleUserAssociationHttpResponse(
-				accountRole.getAccountId(), accountRole.getId(), null));
+			accountRoleResource.
+				postAccountRoleUserAccountAssociationHttpResponse(
+					accountRole.getAccountId(), accountRole.getId(), null));
 
 		assertHttpResponseStatusCode(
 			404,
-			accountRoleResource.postAccountRoleUserAssociationHttpResponse(
-				accountRole.getAccountId(), 0L, null));
+			accountRoleResource.
+				postAccountRoleUserAccountAssociationHttpResponse(
+					accountRole.getAccountId(), 0L, null));
 	}
 
-	protected AccountRole testPostAccountRoleUserAssociation_addAccountRole()
+	protected AccountRole
+			testPostAccountRoleUserAccountAssociation_addAccountRole()
 		throws Exception {
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -202,22 +202,22 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteAccountRoleUserAccountAssociationByExternalReferenceCode()
+	public void testDeleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		AccountRole accountRole =
-			testDeleteAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole();
+			testDeleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole();
 
 		assertHttpResponseStatusCode(
 			204,
 			accountRoleResource.
-				deleteAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+				deleteAccountAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					null, accountRole.getId(), null));
 	}
 
 	protected AccountRole
-			testDeleteAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
+			testDeleteAccountAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -225,28 +225,28 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testPostAccountRoleUserAccountAssociationByExternalReferenceCode()
+	public void testPostAccountAccountRoleUserAccountAssociationByExternalReferenceCode()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		AccountRole accountRole =
-			testPostAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole();
+			testPostAccountAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole();
 
 		assertHttpResponseStatusCode(
 			204,
 			accountRoleResource.
-				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+				postAccountAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					null, accountRole.getId(), null));
 
 		assertHttpResponseStatusCode(
 			404,
 			accountRoleResource.
-				postAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
+				postAccountAccountRoleUserAccountAssociationByExternalReferenceCodeHttpResponse(
 					null, 0L, null));
 	}
 
 	protected AccountRole
-			testPostAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
+			testPostAccountAccountRoleUserAccountAssociationByExternalReferenceCode_addAccountRole()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -254,31 +254,33 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountRolesByExternalReferenceCodePage()
+	public void testGetAccountAccountRolesByExternalReferenceCodePage()
 		throws Exception {
 
 		Page<AccountRole> page =
-			accountRoleResource.getAccountRolesByExternalReferenceCodePage(
-				testGetAccountRolesByExternalReferenceCodePage_getExternalReferenceCode(),
-				RandomTestUtil.randomString(), Pagination.of(1, 2), null);
+			accountRoleResource.
+				getAccountAccountRolesByExternalReferenceCodePage(
+					testGetAccountAccountRolesByExternalReferenceCodePage_getExternalReferenceCode(),
+					RandomTestUtil.randomString(), Pagination.of(1, 2), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
 		String externalReferenceCode =
-			testGetAccountRolesByExternalReferenceCodePage_getExternalReferenceCode();
+			testGetAccountAccountRolesByExternalReferenceCodePage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
-			testGetAccountRolesByExternalReferenceCodePage_getIrrelevantExternalReferenceCode();
+			testGetAccountAccountRolesByExternalReferenceCodePage_getIrrelevantExternalReferenceCode();
 
 		if (irrelevantExternalReferenceCode != null) {
 			AccountRole irrelevantAccountRole =
-				testGetAccountRolesByExternalReferenceCodePage_addAccountRole(
+				testGetAccountAccountRolesByExternalReferenceCodePage_addAccountRole(
 					irrelevantExternalReferenceCode,
 					randomIrrelevantAccountRole());
 
 			page =
-				accountRoleResource.getAccountRolesByExternalReferenceCodePage(
-					irrelevantExternalReferenceCode, null, Pagination.of(1, 2),
-					null);
+				accountRoleResource.
+					getAccountAccountRolesByExternalReferenceCodePage(
+						irrelevantExternalReferenceCode, null,
+						Pagination.of(1, 2), null);
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -289,15 +291,17 @@ public abstract class BaseAccountRoleResourceTestCase {
 		}
 
 		AccountRole accountRole1 =
-			testGetAccountRolesByExternalReferenceCodePage_addAccountRole(
+			testGetAccountAccountRolesByExternalReferenceCodePage_addAccountRole(
 				externalReferenceCode, randomAccountRole());
 
 		AccountRole accountRole2 =
-			testGetAccountRolesByExternalReferenceCodePage_addAccountRole(
+			testGetAccountAccountRolesByExternalReferenceCodePage_addAccountRole(
 				externalReferenceCode, randomAccountRole());
 
-		page = accountRoleResource.getAccountRolesByExternalReferenceCodePage(
-			externalReferenceCode, null, Pagination.of(1, 2), null);
+		page =
+			accountRoleResource.
+				getAccountAccountRolesByExternalReferenceCodePage(
+					externalReferenceCode, null, Pagination.of(1, 2), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -308,35 +312,37 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountRolesByExternalReferenceCodePageWithPagination()
+	public void testGetAccountAccountRolesByExternalReferenceCodePageWithPagination()
 		throws Exception {
 
 		String externalReferenceCode =
-			testGetAccountRolesByExternalReferenceCodePage_getExternalReferenceCode();
+			testGetAccountAccountRolesByExternalReferenceCodePage_getExternalReferenceCode();
 
 		AccountRole accountRole1 =
-			testGetAccountRolesByExternalReferenceCodePage_addAccountRole(
+			testGetAccountAccountRolesByExternalReferenceCodePage_addAccountRole(
 				externalReferenceCode, randomAccountRole());
 
 		AccountRole accountRole2 =
-			testGetAccountRolesByExternalReferenceCodePage_addAccountRole(
+			testGetAccountAccountRolesByExternalReferenceCodePage_addAccountRole(
 				externalReferenceCode, randomAccountRole());
 
 		AccountRole accountRole3 =
-			testGetAccountRolesByExternalReferenceCodePage_addAccountRole(
+			testGetAccountAccountRolesByExternalReferenceCodePage_addAccountRole(
 				externalReferenceCode, randomAccountRole());
 
 		Page<AccountRole> page1 =
-			accountRoleResource.getAccountRolesByExternalReferenceCodePage(
-				externalReferenceCode, null, Pagination.of(1, 2), null);
+			accountRoleResource.
+				getAccountAccountRolesByExternalReferenceCodePage(
+					externalReferenceCode, null, Pagination.of(1, 2), null);
 
 		List<AccountRole> accountRoles1 = (List<AccountRole>)page1.getItems();
 
 		Assert.assertEquals(accountRoles1.toString(), 2, accountRoles1.size());
 
 		Page<AccountRole> page2 =
-			accountRoleResource.getAccountRolesByExternalReferenceCodePage(
-				externalReferenceCode, null, Pagination.of(2, 2), null);
+			accountRoleResource.
+				getAccountAccountRolesByExternalReferenceCodePage(
+					externalReferenceCode, null, Pagination.of(2, 2), null);
 
 		Assert.assertEquals(3, page2.getTotalCount());
 
@@ -345,8 +351,9 @@ public abstract class BaseAccountRoleResourceTestCase {
 		Assert.assertEquals(accountRoles2.toString(), 1, accountRoles2.size());
 
 		Page<AccountRole> page3 =
-			accountRoleResource.getAccountRolesByExternalReferenceCodePage(
-				externalReferenceCode, null, Pagination.of(1, 3), null);
+			accountRoleResource.
+				getAccountAccountRolesByExternalReferenceCodePage(
+					externalReferenceCode, null, Pagination.of(1, 3), null);
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(accountRole1, accountRole2, accountRole3),
@@ -354,10 +361,10 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountRolesByExternalReferenceCodePageWithSortDateTime()
+	public void testGetAccountAccountRolesByExternalReferenceCodePageWithSortDateTime()
 		throws Exception {
 
-		testGetAccountRolesByExternalReferenceCodePageWithSort(
+		testGetAccountAccountRolesByExternalReferenceCodePageWithSort(
 			EntityField.Type.DATE_TIME,
 			(entityField, accountRole1, accountRole2) -> {
 				BeanUtils.setProperty(
@@ -367,10 +374,10 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountRolesByExternalReferenceCodePageWithSortInteger()
+	public void testGetAccountAccountRolesByExternalReferenceCodePageWithSortInteger()
 		throws Exception {
 
-		testGetAccountRolesByExternalReferenceCodePageWithSort(
+		testGetAccountAccountRolesByExternalReferenceCodePageWithSort(
 			EntityField.Type.INTEGER,
 			(entityField, accountRole1, accountRole2) -> {
 				BeanUtils.setProperty(accountRole1, entityField.getName(), 0);
@@ -379,10 +386,10 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountRolesByExternalReferenceCodePageWithSortString()
+	public void testGetAccountAccountRolesByExternalReferenceCodePageWithSortString()
 		throws Exception {
 
-		testGetAccountRolesByExternalReferenceCodePageWithSort(
+		testGetAccountAccountRolesByExternalReferenceCodePageWithSort(
 			EntityField.Type.STRING,
 			(entityField, accountRole1, accountRole2) -> {
 				Class<?> clazz = accountRole1.getClass();
@@ -431,10 +438,12 @@ public abstract class BaseAccountRoleResourceTestCase {
 			});
 	}
 
-	protected void testGetAccountRolesByExternalReferenceCodePageWithSort(
-			EntityField.Type type,
-			UnsafeTriConsumer<EntityField, AccountRole, AccountRole, Exception>
-				unsafeTriConsumer)
+	protected void
+			testGetAccountAccountRolesByExternalReferenceCodePageWithSort(
+				EntityField.Type type,
+				UnsafeTriConsumer
+					<EntityField, AccountRole, AccountRole, Exception>
+						unsafeTriConsumer)
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(type);
@@ -444,7 +453,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 		}
 
 		String externalReferenceCode =
-			testGetAccountRolesByExternalReferenceCodePage_getExternalReferenceCode();
+			testGetAccountAccountRolesByExternalReferenceCodePage_getExternalReferenceCode();
 
 		AccountRole accountRole1 = randomAccountRole();
 		AccountRole accountRole2 = randomAccountRole();
@@ -454,27 +463,29 @@ public abstract class BaseAccountRoleResourceTestCase {
 		}
 
 		accountRole1 =
-			testGetAccountRolesByExternalReferenceCodePage_addAccountRole(
+			testGetAccountAccountRolesByExternalReferenceCodePage_addAccountRole(
 				externalReferenceCode, accountRole1);
 
 		accountRole2 =
-			testGetAccountRolesByExternalReferenceCodePage_addAccountRole(
+			testGetAccountAccountRolesByExternalReferenceCodePage_addAccountRole(
 				externalReferenceCode, accountRole2);
 
 		for (EntityField entityField : entityFields) {
 			Page<AccountRole> ascPage =
-				accountRoleResource.getAccountRolesByExternalReferenceCodePage(
-					externalReferenceCode, null, Pagination.of(1, 2),
-					entityField.getName() + ":asc");
+				accountRoleResource.
+					getAccountAccountRolesByExternalReferenceCodePage(
+						externalReferenceCode, null, Pagination.of(1, 2),
+						entityField.getName() + ":asc");
 
 			assertEquals(
 				Arrays.asList(accountRole1, accountRole2),
 				(List<AccountRole>)ascPage.getItems());
 
 			Page<AccountRole> descPage =
-				accountRoleResource.getAccountRolesByExternalReferenceCodePage(
-					externalReferenceCode, null, Pagination.of(1, 2),
-					entityField.getName() + ":desc");
+				accountRoleResource.
+					getAccountAccountRolesByExternalReferenceCodePage(
+						externalReferenceCode, null, Pagination.of(1, 2),
+						entityField.getName() + ":desc");
 
 			assertEquals(
 				Arrays.asList(accountRole2, accountRole1),
@@ -483,7 +494,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	protected AccountRole
-			testGetAccountRolesByExternalReferenceCodePage_addAccountRole(
+			testGetAccountAccountRolesByExternalReferenceCodePage_addAccountRole(
 				String externalReferenceCode, AccountRole accountRole)
 		throws Exception {
 
@@ -492,7 +503,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	protected String
-			testGetAccountRolesByExternalReferenceCodePage_getExternalReferenceCode()
+			testGetAccountAccountRolesByExternalReferenceCodePage_getExternalReferenceCode()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -500,18 +511,20 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	protected String
-			testGetAccountRolesByExternalReferenceCodePage_getIrrelevantExternalReferenceCode()
+			testGetAccountAccountRolesByExternalReferenceCodePage_getIrrelevantExternalReferenceCode()
 		throws Exception {
 
 		return null;
 	}
 
 	@Test
-	public void testPostAccountRoleByExternalReferenceCode() throws Exception {
+	public void testPostAccountAccountRoleByExternalReferenceCode()
+		throws Exception {
+
 		AccountRole randomAccountRole = randomAccountRole();
 
 		AccountRole postAccountRole =
-			testPostAccountRoleByExternalReferenceCode_addAccountRole(
+			testPostAccountAccountRoleByExternalReferenceCode_addAccountRole(
 				randomAccountRole);
 
 		assertEquals(randomAccountRole, postAccountRole);
@@ -519,7 +532,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	protected AccountRole
-			testPostAccountRoleByExternalReferenceCode_addAccountRole(
+			testPostAccountAccountRoleByExternalReferenceCode_addAccountRole(
 				AccountRole accountRole)
 		throws Exception {
 
@@ -528,23 +541,23 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountRolesPage() throws Exception {
-		Page<AccountRole> page = accountRoleResource.getAccountRolesPage(
-			testGetAccountRolesPage_getAccountId(),
+	public void testGetAccountAccountRolesPage() throws Exception {
+		Page<AccountRole> page = accountRoleResource.getAccountAccountRolesPage(
+			testGetAccountAccountRolesPage_getAccountId(),
 			RandomTestUtil.randomString(), Pagination.of(1, 2), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
-		Long accountId = testGetAccountRolesPage_getAccountId();
+		Long accountId = testGetAccountAccountRolesPage_getAccountId();
 		Long irrelevantAccountId =
-			testGetAccountRolesPage_getIrrelevantAccountId();
+			testGetAccountAccountRolesPage_getIrrelevantAccountId();
 
 		if (irrelevantAccountId != null) {
 			AccountRole irrelevantAccountRole =
-				testGetAccountRolesPage_addAccountRole(
+				testGetAccountAccountRolesPage_addAccountRole(
 					irrelevantAccountId, randomIrrelevantAccountRole());
 
-			page = accountRoleResource.getAccountRolesPage(
+			page = accountRoleResource.getAccountAccountRolesPage(
 				irrelevantAccountId, null, Pagination.of(1, 2), null);
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -555,13 +568,15 @@ public abstract class BaseAccountRoleResourceTestCase {
 			assertValid(page);
 		}
 
-		AccountRole accountRole1 = testGetAccountRolesPage_addAccountRole(
-			accountId, randomAccountRole());
+		AccountRole accountRole1 =
+			testGetAccountAccountRolesPage_addAccountRole(
+				accountId, randomAccountRole());
 
-		AccountRole accountRole2 = testGetAccountRolesPage_addAccountRole(
-			accountId, randomAccountRole());
+		AccountRole accountRole2 =
+			testGetAccountAccountRolesPage_addAccountRole(
+				accountId, randomAccountRole());
 
-		page = accountRoleResource.getAccountRolesPage(
+		page = accountRoleResource.getAccountAccountRolesPage(
 			accountId, null, Pagination.of(1, 2), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -573,27 +588,34 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountRolesPageWithPagination() throws Exception {
-		Long accountId = testGetAccountRolesPage_getAccountId();
+	public void testGetAccountAccountRolesPageWithPagination()
+		throws Exception {
 
-		AccountRole accountRole1 = testGetAccountRolesPage_addAccountRole(
-			accountId, randomAccountRole());
+		Long accountId = testGetAccountAccountRolesPage_getAccountId();
 
-		AccountRole accountRole2 = testGetAccountRolesPage_addAccountRole(
-			accountId, randomAccountRole());
+		AccountRole accountRole1 =
+			testGetAccountAccountRolesPage_addAccountRole(
+				accountId, randomAccountRole());
 
-		AccountRole accountRole3 = testGetAccountRolesPage_addAccountRole(
-			accountId, randomAccountRole());
+		AccountRole accountRole2 =
+			testGetAccountAccountRolesPage_addAccountRole(
+				accountId, randomAccountRole());
 
-		Page<AccountRole> page1 = accountRoleResource.getAccountRolesPage(
-			accountId, null, Pagination.of(1, 2), null);
+		AccountRole accountRole3 =
+			testGetAccountAccountRolesPage_addAccountRole(
+				accountId, randomAccountRole());
+
+		Page<AccountRole> page1 =
+			accountRoleResource.getAccountAccountRolesPage(
+				accountId, null, Pagination.of(1, 2), null);
 
 		List<AccountRole> accountRoles1 = (List<AccountRole>)page1.getItems();
 
 		Assert.assertEquals(accountRoles1.toString(), 2, accountRoles1.size());
 
-		Page<AccountRole> page2 = accountRoleResource.getAccountRolesPage(
-			accountId, null, Pagination.of(2, 2), null);
+		Page<AccountRole> page2 =
+			accountRoleResource.getAccountAccountRolesPage(
+				accountId, null, Pagination.of(2, 2), null);
 
 		Assert.assertEquals(3, page2.getTotalCount());
 
@@ -601,8 +623,9 @@ public abstract class BaseAccountRoleResourceTestCase {
 
 		Assert.assertEquals(accountRoles2.toString(), 1, accountRoles2.size());
 
-		Page<AccountRole> page3 = accountRoleResource.getAccountRolesPage(
-			accountId, null, Pagination.of(1, 3), null);
+		Page<AccountRole> page3 =
+			accountRoleResource.getAccountAccountRolesPage(
+				accountId, null, Pagination.of(1, 3), null);
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(accountRole1, accountRole2, accountRole3),
@@ -610,8 +633,10 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountRolesPageWithSortDateTime() throws Exception {
-		testGetAccountRolesPageWithSort(
+	public void testGetAccountAccountRolesPageWithSortDateTime()
+		throws Exception {
+
+		testGetAccountAccountRolesPageWithSort(
 			EntityField.Type.DATE_TIME,
 			(entityField, accountRole1, accountRole2) -> {
 				BeanUtils.setProperty(
@@ -621,8 +646,10 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountRolesPageWithSortInteger() throws Exception {
-		testGetAccountRolesPageWithSort(
+	public void testGetAccountAccountRolesPageWithSortInteger()
+		throws Exception {
+
+		testGetAccountAccountRolesPageWithSort(
 			EntityField.Type.INTEGER,
 			(entityField, accountRole1, accountRole2) -> {
 				BeanUtils.setProperty(accountRole1, entityField.getName(), 0);
@@ -631,8 +658,10 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountRolesPageWithSortString() throws Exception {
-		testGetAccountRolesPageWithSort(
+	public void testGetAccountAccountRolesPageWithSortString()
+		throws Exception {
+
+		testGetAccountAccountRolesPageWithSort(
 			EntityField.Type.STRING,
 			(entityField, accountRole1, accountRole2) -> {
 				Class<?> clazz = accountRole1.getClass();
@@ -681,7 +710,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 			});
 	}
 
-	protected void testGetAccountRolesPageWithSort(
+	protected void testGetAccountAccountRolesPageWithSort(
 			EntityField.Type type,
 			UnsafeTriConsumer<EntityField, AccountRole, AccountRole, Exception>
 				unsafeTriConsumer)
@@ -693,7 +722,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 			return;
 		}
 
-		Long accountId = testGetAccountRolesPage_getAccountId();
+		Long accountId = testGetAccountAccountRolesPage_getAccountId();
 
 		AccountRole accountRole1 = randomAccountRole();
 		AccountRole accountRole2 = randomAccountRole();
@@ -702,23 +731,24 @@ public abstract class BaseAccountRoleResourceTestCase {
 			unsafeTriConsumer.accept(entityField, accountRole1, accountRole2);
 		}
 
-		accountRole1 = testGetAccountRolesPage_addAccountRole(
+		accountRole1 = testGetAccountAccountRolesPage_addAccountRole(
 			accountId, accountRole1);
 
-		accountRole2 = testGetAccountRolesPage_addAccountRole(
+		accountRole2 = testGetAccountAccountRolesPage_addAccountRole(
 			accountId, accountRole2);
 
 		for (EntityField entityField : entityFields) {
-			Page<AccountRole> ascPage = accountRoleResource.getAccountRolesPage(
-				accountId, null, Pagination.of(1, 2),
-				entityField.getName() + ":asc");
+			Page<AccountRole> ascPage =
+				accountRoleResource.getAccountAccountRolesPage(
+					accountId, null, Pagination.of(1, 2),
+					entityField.getName() + ":asc");
 
 			assertEquals(
 				Arrays.asList(accountRole1, accountRole2),
 				(List<AccountRole>)ascPage.getItems());
 
 			Page<AccountRole> descPage =
-				accountRoleResource.getAccountRolesPage(
+				accountRoleResource.getAccountAccountRolesPage(
 					accountId, null, Pagination.of(1, 2),
 					entityField.getName() + ":desc");
 
@@ -728,98 +758,63 @@ public abstract class BaseAccountRoleResourceTestCase {
 		}
 	}
 
-	protected AccountRole testGetAccountRolesPage_addAccountRole(
+	protected AccountRole testGetAccountAccountRolesPage_addAccountRole(
 			Long accountId, AccountRole accountRole)
+		throws Exception {
+
+		return accountRoleResource.postAccountAccountRole(
+			accountId, accountRole);
+	}
+
+	protected Long testGetAccountAccountRolesPage_getAccountId()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}
 
-	protected Long testGetAccountRolesPage_getAccountId() throws Exception {
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected Long testGetAccountRolesPage_getIrrelevantAccountId()
+	protected Long testGetAccountAccountRolesPage_getIrrelevantAccountId()
 		throws Exception {
 
 		return null;
 	}
 
 	@Test
-	public void testGraphQLGetAccountRolesPage() throws Exception {
-		Long accountId = testGetAccountRolesPage_getAccountId();
-
-		GraphQLField graphQLField = new GraphQLField(
-			"accountRoles",
-			new HashMap<String, Object>() {
-				{
-					put("page", 1);
-					put("pageSize", 2);
-
-					put("accountId", accountId);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
-
-		JSONObject accountRolesJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(graphQLField), "JSONObject/data",
-			"JSONObject/accountRoles");
-
-		Assert.assertEquals(0, accountRolesJSONObject.get("totalCount"));
-
-		AccountRole accountRole1 = testGraphQLAccountRole_addAccountRole();
-		AccountRole accountRole2 = testGraphQLAccountRole_addAccountRole();
-
-		accountRolesJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(graphQLField), "JSONObject/data",
-			"JSONObject/accountRoles");
-
-		Assert.assertEquals(2, accountRolesJSONObject.get("totalCount"));
-
-		assertEqualsIgnoringOrder(
-			Arrays.asList(accountRole1, accountRole2),
-			Arrays.asList(
-				AccountRoleSerDes.toDTOs(
-					accountRolesJSONObject.getString("items"))));
-	}
-
-	@Test
-	public void testPostAccountRole() throws Exception {
+	public void testPostAccountAccountRole() throws Exception {
 		AccountRole randomAccountRole = randomAccountRole();
 
-		AccountRole postAccountRole = testPostAccountRole_addAccountRole(
+		AccountRole postAccountRole = testPostAccountAccountRole_addAccountRole(
 			randomAccountRole);
 
 		assertEquals(randomAccountRole, postAccountRole);
 		assertValid(postAccountRole);
 	}
 
-	protected AccountRole testPostAccountRole_addAccountRole(
+	protected AccountRole testPostAccountAccountRole_addAccountRole(
 			AccountRole accountRole)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		return accountRoleResource.postAccountAccountRole(
+			testGetAccountAccountRolesPage_getAccountId(), accountRole);
 	}
 
 	@Test
-	public void testDeleteAccountRoleUserAccountAssociation() throws Exception {
+	public void testDeleteAccountAccountRoleUserAccountAssociation()
+		throws Exception {
+
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		AccountRole accountRole =
-			testDeleteAccountRoleUserAccountAssociation_addAccountRole();
+			testDeleteAccountAccountRoleUserAccountAssociation_addAccountRole();
 
 		assertHttpResponseStatusCode(
 			204,
 			accountRoleResource.
-				deleteAccountRoleUserAccountAssociationHttpResponse(
+				deleteAccountAccountRoleUserAccountAssociationHttpResponse(
 					accountRole.getAccountId(), accountRole.getId(), null));
 	}
 
 	protected AccountRole
-			testDeleteAccountRoleUserAccountAssociation_addAccountRole()
+			testDeleteAccountAccountRoleUserAccountAssociation_addAccountRole()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -827,26 +822,28 @@ public abstract class BaseAccountRoleResourceTestCase {
 	}
 
 	@Test
-	public void testPostAccountRoleUserAccountAssociation() throws Exception {
+	public void testPostAccountAccountRoleUserAccountAssociation()
+		throws Exception {
+
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		AccountRole accountRole =
-			testPostAccountRoleUserAccountAssociation_addAccountRole();
+			testPostAccountAccountRoleUserAccountAssociation_addAccountRole();
 
 		assertHttpResponseStatusCode(
 			204,
 			accountRoleResource.
-				postAccountRoleUserAccountAssociationHttpResponse(
+				postAccountAccountRoleUserAccountAssociationHttpResponse(
 					accountRole.getAccountId(), accountRole.getId(), null));
 
 		assertHttpResponseStatusCode(
 			404,
 			accountRoleResource.
-				postAccountRoleUserAccountAssociationHttpResponse(
+				postAccountAccountRoleUserAccountAssociationHttpResponse(
 					accountRole.getAccountId(), 0L, null));
 	}
 
 	protected AccountRole
-			testPostAccountRoleUserAccountAssociation_addAccountRole()
+			testPostAccountAccountRoleUserAccountAssociation_addAccountRole()
 		throws Exception {
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -224,31 +224,34 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersByExternalReferenceCodePage()
+	public void testGetAccountUserAccountsByExternalReferenceCodePage()
 		throws Exception {
 
 		Page<UserAccount> page =
-			userAccountResource.getAccountUsersByExternalReferenceCodePage(
-				testGetAccountUsersByExternalReferenceCodePage_getExternalReferenceCode(),
-				RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
+			userAccountResource.
+				getAccountUserAccountsByExternalReferenceCodePage(
+					testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode(),
+					RandomTestUtil.randomString(), null, Pagination.of(1, 2),
+					null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
 		String externalReferenceCode =
-			testGetAccountUsersByExternalReferenceCodePage_getExternalReferenceCode();
+			testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode();
 		String irrelevantExternalReferenceCode =
-			testGetAccountUsersByExternalReferenceCodePage_getIrrelevantExternalReferenceCode();
+			testGetAccountUserAccountsByExternalReferenceCodePage_getIrrelevantExternalReferenceCode();
 
 		if (irrelevantExternalReferenceCode != null) {
 			UserAccount irrelevantUserAccount =
-				testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+				testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 					irrelevantExternalReferenceCode,
 					randomIrrelevantUserAccount());
 
 			page =
-				userAccountResource.getAccountUsersByExternalReferenceCodePage(
-					irrelevantExternalReferenceCode, null, null,
-					Pagination.of(1, 2), null);
+				userAccountResource.
+					getAccountUserAccountsByExternalReferenceCodePage(
+						irrelevantExternalReferenceCode, null, null,
+						Pagination.of(1, 2), null);
 
 			Assert.assertEquals(1, page.getTotalCount());
 
@@ -259,15 +262,18 @@ public abstract class BaseUserAccountResourceTestCase {
 		}
 
 		UserAccount userAccount1 =
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				externalReferenceCode, randomUserAccount());
 
 		UserAccount userAccount2 =
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				externalReferenceCode, randomUserAccount());
 
-		page = userAccountResource.getAccountUsersByExternalReferenceCodePage(
-			externalReferenceCode, null, null, Pagination.of(1, 2), null);
+		page =
+			userAccountResource.
+				getAccountUserAccountsByExternalReferenceCodePage(
+					externalReferenceCode, null, null, Pagination.of(1, 2),
+					null);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -282,7 +288,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersByExternalReferenceCodePageWithFilterDateTimeEquals()
+	public void testGetAccountUserAccountsByExternalReferenceCodePageWithFilterDateTimeEquals()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -293,20 +299,21 @@ public abstract class BaseUserAccountResourceTestCase {
 		}
 
 		String externalReferenceCode =
-			testGetAccountUsersByExternalReferenceCodePage_getExternalReferenceCode();
+			testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode();
 
 		UserAccount userAccount1 = randomUserAccount();
 
 		userAccount1 =
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				externalReferenceCode, userAccount1);
 
 		for (EntityField entityField : entityFields) {
 			Page<UserAccount> page =
-				userAccountResource.getAccountUsersByExternalReferenceCodePage(
-					externalReferenceCode, null,
-					getFilterString(entityField, "between", userAccount1),
-					Pagination.of(1, 2), null);
+				userAccountResource.
+					getAccountUserAccountsByExternalReferenceCodePage(
+						externalReferenceCode, null,
+						getFilterString(entityField, "between", userAccount1),
+						Pagination.of(1, 2), null);
 
 			assertEquals(
 				Collections.singletonList(userAccount1),
@@ -315,7 +322,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersByExternalReferenceCodePageWithFilterStringEquals()
+	public void testGetAccountUserAccountsByExternalReferenceCodePageWithFilterStringEquals()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -326,23 +333,24 @@ public abstract class BaseUserAccountResourceTestCase {
 		}
 
 		String externalReferenceCode =
-			testGetAccountUsersByExternalReferenceCodePage_getExternalReferenceCode();
+			testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode();
 
 		UserAccount userAccount1 =
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				externalReferenceCode, randomUserAccount());
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserAccount userAccount2 =
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				externalReferenceCode, randomUserAccount());
 
 		for (EntityField entityField : entityFields) {
 			Page<UserAccount> page =
-				userAccountResource.getAccountUsersByExternalReferenceCodePage(
-					externalReferenceCode, null,
-					getFilterString(entityField, "eq", userAccount1),
-					Pagination.of(1, 2), null);
+				userAccountResource.
+					getAccountUserAccountsByExternalReferenceCodePage(
+						externalReferenceCode, null,
+						getFilterString(entityField, "eq", userAccount1),
+						Pagination.of(1, 2), null);
 
 			assertEquals(
 				Collections.singletonList(userAccount1),
@@ -351,35 +359,39 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersByExternalReferenceCodePageWithPagination()
+	public void testGetAccountUserAccountsByExternalReferenceCodePageWithPagination()
 		throws Exception {
 
 		String externalReferenceCode =
-			testGetAccountUsersByExternalReferenceCodePage_getExternalReferenceCode();
+			testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode();
 
 		UserAccount userAccount1 =
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				externalReferenceCode, randomUserAccount());
 
 		UserAccount userAccount2 =
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				externalReferenceCode, randomUserAccount());
 
 		UserAccount userAccount3 =
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				externalReferenceCode, randomUserAccount());
 
 		Page<UserAccount> page1 =
-			userAccountResource.getAccountUsersByExternalReferenceCodePage(
-				externalReferenceCode, null, null, Pagination.of(1, 2), null);
+			userAccountResource.
+				getAccountUserAccountsByExternalReferenceCodePage(
+					externalReferenceCode, null, null, Pagination.of(1, 2),
+					null);
 
 		List<UserAccount> userAccounts1 = (List<UserAccount>)page1.getItems();
 
 		Assert.assertEquals(userAccounts1.toString(), 2, userAccounts1.size());
 
 		Page<UserAccount> page2 =
-			userAccountResource.getAccountUsersByExternalReferenceCodePage(
-				externalReferenceCode, null, null, Pagination.of(2, 2), null);
+			userAccountResource.
+				getAccountUserAccountsByExternalReferenceCodePage(
+					externalReferenceCode, null, null, Pagination.of(2, 2),
+					null);
 
 		Assert.assertEquals(3, page2.getTotalCount());
 
@@ -388,8 +400,10 @@ public abstract class BaseUserAccountResourceTestCase {
 		Assert.assertEquals(userAccounts2.toString(), 1, userAccounts2.size());
 
 		Page<UserAccount> page3 =
-			userAccountResource.getAccountUsersByExternalReferenceCodePage(
-				externalReferenceCode, null, null, Pagination.of(1, 3), null);
+			userAccountResource.
+				getAccountUserAccountsByExternalReferenceCodePage(
+					externalReferenceCode, null, null, Pagination.of(1, 3),
+					null);
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(userAccount1, userAccount2, userAccount3),
@@ -397,10 +411,10 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersByExternalReferenceCodePageWithSortDateTime()
+	public void testGetAccountUserAccountsByExternalReferenceCodePageWithSortDateTime()
 		throws Exception {
 
-		testGetAccountUsersByExternalReferenceCodePageWithSort(
+		testGetAccountUserAccountsByExternalReferenceCodePageWithSort(
 			EntityField.Type.DATE_TIME,
 			(entityField, userAccount1, userAccount2) -> {
 				BeanUtils.setProperty(
@@ -410,10 +424,10 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersByExternalReferenceCodePageWithSortInteger()
+	public void testGetAccountUserAccountsByExternalReferenceCodePageWithSortInteger()
 		throws Exception {
 
-		testGetAccountUsersByExternalReferenceCodePageWithSort(
+		testGetAccountUserAccountsByExternalReferenceCodePageWithSort(
 			EntityField.Type.INTEGER,
 			(entityField, userAccount1, userAccount2) -> {
 				BeanUtils.setProperty(userAccount1, entityField.getName(), 0);
@@ -422,10 +436,10 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersByExternalReferenceCodePageWithSortString()
+	public void testGetAccountUserAccountsByExternalReferenceCodePageWithSortString()
 		throws Exception {
 
-		testGetAccountUsersByExternalReferenceCodePageWithSort(
+		testGetAccountUserAccountsByExternalReferenceCodePageWithSort(
 			EntityField.Type.STRING,
 			(entityField, userAccount1, userAccount2) -> {
 				Class<?> clazz = userAccount1.getClass();
@@ -474,10 +488,12 @@ public abstract class BaseUserAccountResourceTestCase {
 			});
 	}
 
-	protected void testGetAccountUsersByExternalReferenceCodePageWithSort(
-			EntityField.Type type,
-			UnsafeTriConsumer<EntityField, UserAccount, UserAccount, Exception>
-				unsafeTriConsumer)
+	protected void
+			testGetAccountUserAccountsByExternalReferenceCodePageWithSort(
+				EntityField.Type type,
+				UnsafeTriConsumer
+					<EntityField, UserAccount, UserAccount, Exception>
+						unsafeTriConsumer)
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(type);
@@ -487,7 +503,7 @@ public abstract class BaseUserAccountResourceTestCase {
 		}
 
 		String externalReferenceCode =
-			testGetAccountUsersByExternalReferenceCodePage_getExternalReferenceCode();
+			testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode();
 
 		UserAccount userAccount1 = randomUserAccount();
 		UserAccount userAccount2 = randomUserAccount();
@@ -497,27 +513,29 @@ public abstract class BaseUserAccountResourceTestCase {
 		}
 
 		userAccount1 =
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				externalReferenceCode, userAccount1);
 
 		userAccount2 =
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				externalReferenceCode, userAccount2);
 
 		for (EntityField entityField : entityFields) {
 			Page<UserAccount> ascPage =
-				userAccountResource.getAccountUsersByExternalReferenceCodePage(
-					externalReferenceCode, null, null, Pagination.of(1, 2),
-					entityField.getName() + ":asc");
+				userAccountResource.
+					getAccountUserAccountsByExternalReferenceCodePage(
+						externalReferenceCode, null, null, Pagination.of(1, 2),
+						entityField.getName() + ":asc");
 
 			assertEquals(
 				Arrays.asList(userAccount1, userAccount2),
 				(List<UserAccount>)ascPage.getItems());
 
 			Page<UserAccount> descPage =
-				userAccountResource.getAccountUsersByExternalReferenceCodePage(
-					externalReferenceCode, null, null, Pagination.of(1, 2),
-					entityField.getName() + ":desc");
+				userAccountResource.
+					getAccountUserAccountsByExternalReferenceCodePage(
+						externalReferenceCode, null, null, Pagination.of(1, 2),
+						entityField.getName() + ":desc");
 
 			assertEquals(
 				Arrays.asList(userAccount2, userAccount1),
@@ -526,7 +544,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	protected UserAccount
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				String externalReferenceCode, UserAccount userAccount)
 		throws Exception {
 
@@ -535,7 +553,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	protected String
-			testGetAccountUsersByExternalReferenceCodePage_getExternalReferenceCode()
+			testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -543,18 +561,20 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	protected String
-			testGetAccountUsersByExternalReferenceCodePage_getIrrelevantExternalReferenceCode()
+			testGetAccountUserAccountsByExternalReferenceCodePage_getIrrelevantExternalReferenceCode()
 		throws Exception {
 
 		return null;
 	}
 
 	@Test
-	public void testPostAccountUserByExternalReferenceCode() throws Exception {
+	public void testPostAccountUserAccountByExternalReferenceCode()
+		throws Exception {
+
 		UserAccount randomUserAccount = randomUserAccount();
 
 		UserAccount postUserAccount =
-			testPostAccountUserByExternalReferenceCode_addUserAccount(
+			testPostAccountUserAccountByExternalReferenceCode_addUserAccount(
 				randomUserAccount);
 
 		assertEquals(randomUserAccount, postUserAccount);
@@ -562,7 +582,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	protected UserAccount
-			testPostAccountUserByExternalReferenceCode_addUserAccount(
+			testPostAccountUserAccountByExternalReferenceCode_addUserAccount(
 				UserAccount userAccount)
 		throws Exception {
 
@@ -571,22 +591,22 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteAccountUsersByExternalReferenceCodeByEmailAddress()
+	public void testDeleteAccountUserAccountsByExternalReferenceCodeByEmailAddress()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserAccount userAccount =
-			testDeleteAccountUsersByExternalReferenceCodeByEmailAddress_addUserAccount();
+			testDeleteAccountUserAccountsByExternalReferenceCodeByEmailAddress_addUserAccount();
 
 		assertHttpResponseStatusCode(
 			204,
 			userAccountResource.
-				deleteAccountUsersByExternalReferenceCodeByEmailAddressHttpResponse(
+				deleteAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
 					userAccount.getExternalReferenceCode(), null));
 	}
 
 	protected UserAccount
-			testDeleteAccountUsersByExternalReferenceCodeByEmailAddress_addUserAccount()
+			testDeleteAccountUserAccountsByExternalReferenceCodeByEmailAddress_addUserAccount()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -594,28 +614,28 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testPostAccountUsersByExternalReferenceCodeByEmailAddress()
+	public void testPostAccountUserAccountsByExternalReferenceCodeByEmailAddress()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserAccount userAccount =
-			testPostAccountUsersByExternalReferenceCodeByEmailAddress_addUserAccount();
+			testPostAccountUserAccountsByExternalReferenceCodeByEmailAddress_addUserAccount();
 
 		assertHttpResponseStatusCode(
 			204,
 			userAccountResource.
-				postAccountUsersByExternalReferenceCodeByEmailAddressHttpResponse(
+				postAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
 					userAccount.getExternalReferenceCode(), null));
 
 		assertHttpResponseStatusCode(
 			404,
 			userAccountResource.
-				postAccountUsersByExternalReferenceCodeByEmailAddressHttpResponse(
+				postAccountUserAccountsByExternalReferenceCodeByEmailAddressHttpResponse(
 					userAccount.getExternalReferenceCode(), null));
 	}
 
 	protected UserAccount
-			testPostAccountUsersByExternalReferenceCodeByEmailAddress_addUserAccount()
+			testPostAccountUserAccountsByExternalReferenceCodeByEmailAddress_addUserAccount()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -623,23 +643,23 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteAccountUserByExternalReferenceCodeByEmailAddress()
+	public void testDeleteAccountUserAccountByExternalReferenceCodeByEmailAddress()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserAccount userAccount =
-			testDeleteAccountUserByExternalReferenceCodeByEmailAddress_addUserAccount();
+			testDeleteAccountUserAccountByExternalReferenceCodeByEmailAddress_addUserAccount();
 
 		assertHttpResponseStatusCode(
 			204,
 			userAccountResource.
-				deleteAccountUserByExternalReferenceCodeByEmailAddressHttpResponse(
+				deleteAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
 					userAccount.getExternalReferenceCode(),
 					userAccount.getEmailAddress()));
 	}
 
 	protected UserAccount
-			testDeleteAccountUserByExternalReferenceCodeByEmailAddress_addUserAccount()
+			testDeleteAccountUserAccountByExternalReferenceCodeByEmailAddress_addUserAccount()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -647,30 +667,30 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testPostAccountUserByExternalReferenceCodeByEmailAddress()
+	public void testPostAccountUserAccountByExternalReferenceCodeByEmailAddress()
 		throws Exception {
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserAccount userAccount =
-			testPostAccountUserByExternalReferenceCodeByEmailAddress_addUserAccount();
+			testPostAccountUserAccountByExternalReferenceCodeByEmailAddress_addUserAccount();
 
 		assertHttpResponseStatusCode(
 			204,
 			userAccountResource.
-				postAccountUserByExternalReferenceCodeByEmailAddressHttpResponse(
+				postAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
 					userAccount.getExternalReferenceCode(),
 					userAccount.getEmailAddress()));
 
 		assertHttpResponseStatusCode(
 			404,
 			userAccountResource.
-				postAccountUserByExternalReferenceCodeByEmailAddressHttpResponse(
+				postAccountUserAccountByExternalReferenceCodeByEmailAddressHttpResponse(
 					userAccount.getExternalReferenceCode(),
 					userAccount.getEmailAddress()));
 	}
 
 	protected UserAccount
-			testPostAccountUserByExternalReferenceCodeByEmailAddress_addUserAccount()
+			testPostAccountUserAccountByExternalReferenceCodeByEmailAddress_addUserAccount()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -678,23 +698,23 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersPage() throws Exception {
-		Page<UserAccount> page = userAccountResource.getAccountUsersPage(
-			testGetAccountUsersPage_getAccountId(),
+	public void testGetAccountUserAccountsPage() throws Exception {
+		Page<UserAccount> page = userAccountResource.getAccountUserAccountsPage(
+			testGetAccountUserAccountsPage_getAccountId(),
 			RandomTestUtil.randomString(), null, Pagination.of(1, 2), null);
 
 		Assert.assertEquals(0, page.getTotalCount());
 
-		Long accountId = testGetAccountUsersPage_getAccountId();
+		Long accountId = testGetAccountUserAccountsPage_getAccountId();
 		Long irrelevantAccountId =
-			testGetAccountUsersPage_getIrrelevantAccountId();
+			testGetAccountUserAccountsPage_getIrrelevantAccountId();
 
 		if (irrelevantAccountId != null) {
 			UserAccount irrelevantUserAccount =
-				testGetAccountUsersPage_addUserAccount(
+				testGetAccountUserAccountsPage_addUserAccount(
 					irrelevantAccountId, randomIrrelevantUserAccount());
 
-			page = userAccountResource.getAccountUsersPage(
+			page = userAccountResource.getAccountUserAccountsPage(
 				irrelevantAccountId, null, null, Pagination.of(1, 2), null);
 
 			Assert.assertEquals(1, page.getTotalCount());
@@ -705,13 +725,15 @@ public abstract class BaseUserAccountResourceTestCase {
 			assertValid(page);
 		}
 
-		UserAccount userAccount1 = testGetAccountUsersPage_addUserAccount(
-			accountId, randomUserAccount());
+		UserAccount userAccount1 =
+			testGetAccountUserAccountsPage_addUserAccount(
+				accountId, randomUserAccount());
 
-		UserAccount userAccount2 = testGetAccountUsersPage_addUserAccount(
-			accountId, randomUserAccount());
+		UserAccount userAccount2 =
+			testGetAccountUserAccountsPage_addUserAccount(
+				accountId, randomUserAccount());
 
-		page = userAccountResource.getAccountUsersPage(
+		page = userAccountResource.getAccountUserAccountsPage(
 			accountId, null, null, Pagination.of(1, 2), null);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -727,7 +749,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersPageWithFilterDateTimeEquals()
+	public void testGetAccountUserAccountsPageWithFilterDateTimeEquals()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -737,18 +759,19 @@ public abstract class BaseUserAccountResourceTestCase {
 			return;
 		}
 
-		Long accountId = testGetAccountUsersPage_getAccountId();
+		Long accountId = testGetAccountUserAccountsPage_getAccountId();
 
 		UserAccount userAccount1 = randomUserAccount();
 
-		userAccount1 = testGetAccountUsersPage_addUserAccount(
+		userAccount1 = testGetAccountUserAccountsPage_addUserAccount(
 			accountId, userAccount1);
 
 		for (EntityField entityField : entityFields) {
-			Page<UserAccount> page = userAccountResource.getAccountUsersPage(
-				accountId, null,
-				getFilterString(entityField, "between", userAccount1),
-				Pagination.of(1, 2), null);
+			Page<UserAccount> page =
+				userAccountResource.getAccountUserAccountsPage(
+					accountId, null,
+					getFilterString(entityField, "between", userAccount1),
+					Pagination.of(1, 2), null);
 
 			assertEquals(
 				Collections.singletonList(userAccount1),
@@ -757,7 +780,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersPageWithFilterStringEquals()
+	public void testGetAccountUserAccountsPageWithFilterStringEquals()
 		throws Exception {
 
 		List<EntityField> entityFields = getEntityFields(
@@ -767,20 +790,23 @@ public abstract class BaseUserAccountResourceTestCase {
 			return;
 		}
 
-		Long accountId = testGetAccountUsersPage_getAccountId();
+		Long accountId = testGetAccountUserAccountsPage_getAccountId();
 
-		UserAccount userAccount1 = testGetAccountUsersPage_addUserAccount(
-			accountId, randomUserAccount());
+		UserAccount userAccount1 =
+			testGetAccountUserAccountsPage_addUserAccount(
+				accountId, randomUserAccount());
 
 		@SuppressWarnings("PMD.UnusedLocalVariable")
-		UserAccount userAccount2 = testGetAccountUsersPage_addUserAccount(
-			accountId, randomUserAccount());
+		UserAccount userAccount2 =
+			testGetAccountUserAccountsPage_addUserAccount(
+				accountId, randomUserAccount());
 
 		for (EntityField entityField : entityFields) {
-			Page<UserAccount> page = userAccountResource.getAccountUsersPage(
-				accountId, null,
-				getFilterString(entityField, "eq", userAccount1),
-				Pagination.of(1, 2), null);
+			Page<UserAccount> page =
+				userAccountResource.getAccountUserAccountsPage(
+					accountId, null,
+					getFilterString(entityField, "eq", userAccount1),
+					Pagination.of(1, 2), null);
 
 			assertEquals(
 				Collections.singletonList(userAccount1),
@@ -789,27 +815,34 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersPageWithPagination() throws Exception {
-		Long accountId = testGetAccountUsersPage_getAccountId();
+	public void testGetAccountUserAccountsPageWithPagination()
+		throws Exception {
 
-		UserAccount userAccount1 = testGetAccountUsersPage_addUserAccount(
-			accountId, randomUserAccount());
+		Long accountId = testGetAccountUserAccountsPage_getAccountId();
 
-		UserAccount userAccount2 = testGetAccountUsersPage_addUserAccount(
-			accountId, randomUserAccount());
+		UserAccount userAccount1 =
+			testGetAccountUserAccountsPage_addUserAccount(
+				accountId, randomUserAccount());
 
-		UserAccount userAccount3 = testGetAccountUsersPage_addUserAccount(
-			accountId, randomUserAccount());
+		UserAccount userAccount2 =
+			testGetAccountUserAccountsPage_addUserAccount(
+				accountId, randomUserAccount());
 
-		Page<UserAccount> page1 = userAccountResource.getAccountUsersPage(
-			accountId, null, null, Pagination.of(1, 2), null);
+		UserAccount userAccount3 =
+			testGetAccountUserAccountsPage_addUserAccount(
+				accountId, randomUserAccount());
+
+		Page<UserAccount> page1 =
+			userAccountResource.getAccountUserAccountsPage(
+				accountId, null, null, Pagination.of(1, 2), null);
 
 		List<UserAccount> userAccounts1 = (List<UserAccount>)page1.getItems();
 
 		Assert.assertEquals(userAccounts1.toString(), 2, userAccounts1.size());
 
-		Page<UserAccount> page2 = userAccountResource.getAccountUsersPage(
-			accountId, null, null, Pagination.of(2, 2), null);
+		Page<UserAccount> page2 =
+			userAccountResource.getAccountUserAccountsPage(
+				accountId, null, null, Pagination.of(2, 2), null);
 
 		Assert.assertEquals(3, page2.getTotalCount());
 
@@ -817,8 +850,9 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		Assert.assertEquals(userAccounts2.toString(), 1, userAccounts2.size());
 
-		Page<UserAccount> page3 = userAccountResource.getAccountUsersPage(
-			accountId, null, null, Pagination.of(1, 3), null);
+		Page<UserAccount> page3 =
+			userAccountResource.getAccountUserAccountsPage(
+				accountId, null, null, Pagination.of(1, 3), null);
 
 		assertEqualsIgnoringOrder(
 			Arrays.asList(userAccount1, userAccount2, userAccount3),
@@ -826,8 +860,10 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersPageWithSortDateTime() throws Exception {
-		testGetAccountUsersPageWithSort(
+	public void testGetAccountUserAccountsPageWithSortDateTime()
+		throws Exception {
+
+		testGetAccountUserAccountsPageWithSort(
 			EntityField.Type.DATE_TIME,
 			(entityField, userAccount1, userAccount2) -> {
 				BeanUtils.setProperty(
@@ -837,8 +873,10 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersPageWithSortInteger() throws Exception {
-		testGetAccountUsersPageWithSort(
+	public void testGetAccountUserAccountsPageWithSortInteger()
+		throws Exception {
+
+		testGetAccountUserAccountsPageWithSort(
 			EntityField.Type.INTEGER,
 			(entityField, userAccount1, userAccount2) -> {
 				BeanUtils.setProperty(userAccount1, entityField.getName(), 0);
@@ -847,8 +885,10 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testGetAccountUsersPageWithSortString() throws Exception {
-		testGetAccountUsersPageWithSort(
+	public void testGetAccountUserAccountsPageWithSortString()
+		throws Exception {
+
+		testGetAccountUserAccountsPageWithSort(
 			EntityField.Type.STRING,
 			(entityField, userAccount1, userAccount2) -> {
 				Class<?> clazz = userAccount1.getClass();
@@ -897,7 +937,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			});
 	}
 
-	protected void testGetAccountUsersPageWithSort(
+	protected void testGetAccountUserAccountsPageWithSort(
 			EntityField.Type type,
 			UnsafeTriConsumer<EntityField, UserAccount, UserAccount, Exception>
 				unsafeTriConsumer)
@@ -909,7 +949,7 @@ public abstract class BaseUserAccountResourceTestCase {
 			return;
 		}
 
-		Long accountId = testGetAccountUsersPage_getAccountId();
+		Long accountId = testGetAccountUserAccountsPage_getAccountId();
 
 		UserAccount userAccount1 = randomUserAccount();
 		UserAccount userAccount2 = randomUserAccount();
@@ -918,23 +958,24 @@ public abstract class BaseUserAccountResourceTestCase {
 			unsafeTriConsumer.accept(entityField, userAccount1, userAccount2);
 		}
 
-		userAccount1 = testGetAccountUsersPage_addUserAccount(
+		userAccount1 = testGetAccountUserAccountsPage_addUserAccount(
 			accountId, userAccount1);
 
-		userAccount2 = testGetAccountUsersPage_addUserAccount(
+		userAccount2 = testGetAccountUserAccountsPage_addUserAccount(
 			accountId, userAccount2);
 
 		for (EntityField entityField : entityFields) {
-			Page<UserAccount> ascPage = userAccountResource.getAccountUsersPage(
-				accountId, null, null, Pagination.of(1, 2),
-				entityField.getName() + ":asc");
+			Page<UserAccount> ascPage =
+				userAccountResource.getAccountUserAccountsPage(
+					accountId, null, null, Pagination.of(1, 2),
+					entityField.getName() + ":asc");
 
 			assertEquals(
 				Arrays.asList(userAccount1, userAccount2),
 				(List<UserAccount>)ascPage.getItems());
 
 			Page<UserAccount> descPage =
-				userAccountResource.getAccountUsersPage(
+				userAccountResource.getAccountUserAccountsPage(
 					accountId, null, null, Pagination.of(1, 2),
 					entityField.getName() + ":desc");
 
@@ -944,57 +985,61 @@ public abstract class BaseUserAccountResourceTestCase {
 		}
 	}
 
-	protected UserAccount testGetAccountUsersPage_addUserAccount(
+	protected UserAccount testGetAccountUserAccountsPage_addUserAccount(
 			Long accountId, UserAccount userAccount)
+		throws Exception {
+
+		return userAccountResource.postAccountUserAccount(
+			accountId, userAccount);
+	}
+
+	protected Long testGetAccountUserAccountsPage_getAccountId()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}
 
-	protected Long testGetAccountUsersPage_getAccountId() throws Exception {
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	protected Long testGetAccountUsersPage_getIrrelevantAccountId()
+	protected Long testGetAccountUserAccountsPage_getIrrelevantAccountId()
 		throws Exception {
 
 		return null;
 	}
 
 	@Test
-	public void testPostAccountUser() throws Exception {
+	public void testPostAccountUserAccount() throws Exception {
 		UserAccount randomUserAccount = randomUserAccount();
 
-		UserAccount postUserAccount = testPostAccountUser_addUserAccount(
+		UserAccount postUserAccount = testPostAccountUserAccount_addUserAccount(
 			randomUserAccount);
 
 		assertEquals(randomUserAccount, postUserAccount);
 		assertValid(postUserAccount);
 	}
 
-	protected UserAccount testPostAccountUser_addUserAccount(
+	protected UserAccount testPostAccountUserAccount_addUserAccount(
 			UserAccount userAccount)
 		throws Exception {
 
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
+		return userAccountResource.postAccountUserAccount(
+			testGetAccountUserAccountsPage_getAccountId(), userAccount);
 	}
 
 	@Test
-	public void testDeleteAccountUsersByEmailAddress() throws Exception {
+	public void testDeleteAccountUserAccountsByEmailAddress() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserAccount userAccount =
-			testDeleteAccountUsersByEmailAddress_addUserAccount();
+			testDeleteAccountUserAccountsByEmailAddress_addUserAccount();
 
 		assertHttpResponseStatusCode(
 			204,
-			userAccountResource.deleteAccountUsersByEmailAddressHttpResponse(
-				null, null));
+			userAccountResource.
+				deleteAccountUserAccountsByEmailAddressHttpResponse(
+					null, null));
 	}
 
-	protected UserAccount testDeleteAccountUsersByEmailAddress_addUserAccount()
+	protected UserAccount
+			testDeleteAccountUserAccountsByEmailAddress_addUserAccount()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -1002,23 +1047,24 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testPostAccountUsersByEmailAddress() throws Exception {
+	public void testPostAccountUserAccountsByEmailAddress() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserAccount userAccount =
-			testPostAccountUsersByEmailAddress_addUserAccount();
+			testPostAccountUserAccountsByEmailAddress_addUserAccount();
 
 		assertHttpResponseStatusCode(
 			204,
-			userAccountResource.postAccountUsersByEmailAddressHttpResponse(
-				null, null));
+			userAccountResource.
+				postAccountUserAccountsByEmailAddressHttpResponse(null, null));
 
 		assertHttpResponseStatusCode(
 			404,
-			userAccountResource.postAccountUsersByEmailAddressHttpResponse(
-				null, null));
+			userAccountResource.
+				postAccountUserAccountsByEmailAddressHttpResponse(null, null));
 	}
 
-	protected UserAccount testPostAccountUsersByEmailAddress_addUserAccount()
+	protected UserAccount
+			testPostAccountUserAccountsByEmailAddress_addUserAccount()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -1026,18 +1072,20 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testDeleteAccountUserByEmailAddress() throws Exception {
+	public void testDeleteAccountUserAccountByEmailAddress() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserAccount userAccount =
-			testDeleteAccountUserByEmailAddress_addUserAccount();
+			testDeleteAccountUserAccountByEmailAddress_addUserAccount();
 
 		assertHttpResponseStatusCode(
 			204,
-			userAccountResource.deleteAccountUserByEmailAddressHttpResponse(
-				null, userAccount.getEmailAddress()));
+			userAccountResource.
+				deleteAccountUserAccountByEmailAddressHttpResponse(
+					null, userAccount.getEmailAddress()));
 	}
 
-	protected UserAccount testDeleteAccountUserByEmailAddress_addUserAccount()
+	protected UserAccount
+			testDeleteAccountUserAccountByEmailAddress_addUserAccount()
 		throws Exception {
 
 		throw new UnsupportedOperationException(
@@ -1045,23 +1093,26 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
-	public void testPostAccountUserByEmailAddress() throws Exception {
+	public void testPostAccountUserAccountByEmailAddress() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		UserAccount userAccount =
-			testPostAccountUserByEmailAddress_addUserAccount();
+			testPostAccountUserAccountByEmailAddress_addUserAccount();
 
 		assertHttpResponseStatusCode(
 			204,
-			userAccountResource.postAccountUserByEmailAddressHttpResponse(
-				null, userAccount.getEmailAddress()));
+			userAccountResource.
+				postAccountUserAccountByEmailAddressHttpResponse(
+					null, userAccount.getEmailAddress()));
 
 		assertHttpResponseStatusCode(
 			404,
-			userAccountResource.postAccountUserByEmailAddressHttpResponse(
-				null, userAccount.getEmailAddress()));
+			userAccountResource.
+				postAccountUserAccountByEmailAddressHttpResponse(
+					null, userAccount.getEmailAddress()));
 	}
 
-	protected UserAccount testPostAccountUserByEmailAddress_addUserAccount()
+	protected UserAccount
+			testPostAccountUserAccountByEmailAddress_addUserAccount()
 		throws Exception {
 
 		throw new UnsupportedOperationException(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -107,7 +107,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	@Test
-	public void testDeleteAccountUserByEmailAddress() throws Exception {
+	public void testDeleteAccountUserAccountByEmailAddress() throws Exception {
 		User user = UserTestUtil.addUser();
 
 		_accountEntryUserRelLocalService.addAccountEntryUserRel(
@@ -117,7 +117,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			_accountEntryUserRelLocalService.fetchAccountEntryUserRel(
 				_accountEntry.getAccountEntryId(), user.getUserId()));
 
-		userAccountResource.deleteAccountUserByEmailAddress(
+		userAccountResource.deleteAccountUserAccountByEmailAddress(
 			_accountEntry.getAccountEntryId(), user.getEmailAddress());
 
 		Assert.assertNull(
@@ -127,7 +127,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	@Test
-	public void testDeleteAccountUserByExternalReferenceCodeByEmailAddress()
+	public void testDeleteAccountUserAccountByExternalReferenceCodeByEmailAddress()
 		throws Exception {
 
 		User user = UserTestUtil.addUser();
@@ -140,7 +140,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 				_accountEntry.getAccountEntryId(), user.getUserId()));
 
 		userAccountResource.
-			deleteAccountUserByExternalReferenceCodeByEmailAddress(
+			deleteAccountUserAccountByExternalReferenceCodeByEmailAddress(
 				_accountEntry.getExternalReferenceCode(),
 				user.getEmailAddress());
 
@@ -151,7 +151,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	@Test
-	public void testDeleteAccountUsersByEmailAddress() throws Exception {
+	public void testDeleteAccountUserAccountsByEmailAddress() throws Exception {
 		List<User> users = Arrays.asList(
 			UserTestUtil.addUser(), UserTestUtil.addUser(),
 			UserTestUtil.addUser(), UserTestUtil.addUser());
@@ -167,7 +167,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 		List<User> removeUsers = users.subList(0, 2);
 
-		userAccountResource.deleteAccountUsersByEmailAddress(
+		userAccountResource.deleteAccountUserAccountsByEmailAddress(
 			_accountEntry.getAccountEntryId(), _toEmailAddresses(removeUsers));
 
 		for (User user : removeUsers) {
@@ -187,7 +187,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	@Test
-	public void testDeleteAccountUsersByExternalReferenceCodeByEmailAddress()
+	public void testDeleteAccountUserAccountsByExternalReferenceCodeByEmailAddress()
 		throws Exception {
 
 		List<User> users = Arrays.asList(
@@ -206,7 +206,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		List<User> removeUsers = users.subList(0, 2);
 
 		userAccountResource.
-			deleteAccountUsersByExternalReferenceCodeByEmailAddress(
+			deleteAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 				_accountEntry.getExternalReferenceCode(),
 				_toEmailAddresses(removeUsers));
 
@@ -383,8 +383,8 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	@Test
-	public void testPostAccountUser() throws Exception {
-		super.testPostAccountUser();
+	public void testPostAccountUserAccount() throws Exception {
+		super.testPostAccountUserAccount();
 
 		UserAccount randomUserAccount = randomUserAccount();
 
@@ -393,7 +393,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 				TestPropsValues.getCompanyId(),
 				randomUserAccount.getEmailAddress()));
 
-		randomUserAccount = testPostAccountUser_addAccountUser(
+		randomUserAccount = testPostAccountUserAccount_addUserAccount(
 			randomUserAccount);
 
 		Assert.assertNotNull(
@@ -408,14 +408,14 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	@Test
-	public void testPostAccountUserByEmailAddress() throws Exception {
+	public void testPostAccountUserAccountByEmailAddress() throws Exception {
 		User user = UserTestUtil.addUser();
 
 		Assert.assertNull(
 			_accountEntryUserRelLocalService.fetchAccountEntryUserRel(
 				_accountEntry.getAccountEntryId(), user.getUserId()));
 
-		userAccountResource.postAccountUserByEmailAddress(
+		userAccountResource.postAccountUserAccountByEmailAddress(
 			_accountEntry.getAccountEntryId(), user.getEmailAddress());
 
 		Assert.assertNotNull(
@@ -425,7 +425,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	@Test
-	public void testPostAccountUserByExternalReferenceCodeByEmailAddress()
+	public void testPostAccountUserAccountByExternalReferenceCodeByEmailAddress()
 		throws Exception {
 
 		User user = UserTestUtil.addUser();
@@ -435,7 +435,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 				_accountEntry.getAccountEntryId(), user.getUserId()));
 
 		userAccountResource.
-			postAccountUserByExternalReferenceCodeByEmailAddress(
+			postAccountUserAccountByExternalReferenceCodeByEmailAddress(
 				_accountEntry.getExternalReferenceCode(),
 				user.getEmailAddress());
 
@@ -446,7 +446,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	@Test
-	public void testPostAccountUsersByEmailAddress() throws Exception {
+	public void testPostAccountUserAccountsByEmailAddress() throws Exception {
 		List<User> users = Arrays.asList(
 			UserTestUtil.addUser(), UserTestUtil.addUser(),
 			UserTestUtil.addUser(), UserTestUtil.addUser());
@@ -457,7 +457,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 					_accountEntry.getAccountEntryId(), user.getUserId()));
 		}
 
-		userAccountResource.postAccountUsersByEmailAddress(
+		userAccountResource.postAccountUserAccountsByEmailAddress(
 			_accountEntry.getAccountEntryId(), _toEmailAddresses(users));
 
 		for (User user : users) {
@@ -469,7 +469,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	@Test
-	public void testPostAccountUsersByExternalReferenceCodeByEmailAddress()
+	public void testPostAccountUserAccountsByExternalReferenceCodeByEmailAddress()
 		throws Exception {
 
 		List<User> users = Arrays.asList(
@@ -483,7 +483,7 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		}
 
 		userAccountResource.
-			postAccountUsersByExternalReferenceCodeByEmailAddress(
+			postAccountUserAccountsByExternalReferenceCodeByEmailAddress(
 				_accountEntry.getExternalReferenceCode(),
 				_toEmailAddresses(users));
 
@@ -569,7 +569,8 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	}
 
 	@Override
-	protected UserAccount testDeleteAccountUserByEmailAddress_addUserAccount()
+	protected UserAccount
+			testDeleteAccountUserAccountByEmailAddress_addUserAccount()
 		throws Exception {
 
 		return _addUserAccount(testGroup.getGroupId(), randomUserAccount());
@@ -577,14 +578,15 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	protected UserAccount
-			testDeleteAccountUserByExternalReferenceCodeByEmailAddress_addUserAccount()
+			testDeleteAccountUserAccountByExternalReferenceCodeByEmailAddress_addUserAccount()
 		throws Exception {
 
 		return _addUserAccount(testGroup.getGroupId(), randomUserAccount());
 	}
 
 	@Override
-	protected UserAccount testDeleteAccountUsersByEmailAddress_addUserAccount()
+	protected UserAccount
+			testDeleteAccountUserAccountsByEmailAddress_addUserAccount()
 		throws Exception {
 
 		return _addUserAccount(testGroup.getGroupId(), randomUserAccount());
@@ -608,31 +610,33 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 	@Override
 	protected UserAccount
-			testGetAccountUsersByExternalReferenceCodePage_addUserAccount(
+			testGetAccountUserAccountsByExternalReferenceCodePage_addUserAccount(
 				String externalReferenceCode, UserAccount userAccount)
 		throws Exception {
 
-		return userAccountResource.postAccountUserByExternalReferenceCode(
-			externalReferenceCode, userAccount);
+		return userAccountResource.
+			postAccountUserAccountByExternalReferenceCode(
+				externalReferenceCode, userAccount);
 	}
 
 	@Override
 	protected String
-		testGetAccountUsersByExternalReferenceCodePage_getExternalReferenceCode() {
+		testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode() {
 
 		return _accountEntry.getExternalReferenceCode();
 	}
 
 	@Override
-	protected UserAccount testGetAccountUsersPage_addUserAccount(
+	protected UserAccount testGetAccountUserAccountsPage_addUserAccount(
 			Long accountId, UserAccount userAccount)
 		throws Exception {
 
-		return userAccountResource.postAccountUser(accountId, userAccount);
+		return userAccountResource.postAccountUserAccount(
+			accountId, userAccount);
 	}
 
 	@Override
-	protected Long testGetAccountUsersPage_getAccountId() {
+	protected Long testGetAccountUserAccountsPage_getAccountId() {
 		return _getAccountEntryId();
 	}
 
@@ -713,29 +717,22 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		return _addUserAccount(testGroup.getGroupId(), randomUserAccount());
 	}
 
-	protected UserAccount testPostAccountUser_addAccountUser(
+	protected UserAccount testPostAccountUserAccount_addUserAccount(
 			UserAccount userAccount)
 		throws Exception {
 
-		return _addAccountUser(_getAccountEntryId(), userAccount);
-	}
-
-	@Override
-	protected UserAccount testPostAccountUser_addUserAccount(
-			UserAccount userAccount)
-		throws Exception {
-
-		return userAccountResource.postUserAccount(userAccount);
+		return _addAccountUserAccount(_getAccountEntryId(), userAccount);
 	}
 
 	@Override
 	protected UserAccount
-			testPostAccountUserByExternalReferenceCode_addUserAccount(
+			testPostAccountUserAccountByExternalReferenceCode_addUserAccount(
 				UserAccount userAccount)
 		throws Exception {
 
-		return userAccountResource.postAccountUserByExternalReferenceCode(
-			_accountEntry.getExternalReferenceCode(), userAccount);
+		return userAccountResource.
+			postAccountUserAccountByExternalReferenceCode(
+				_accountEntry.getExternalReferenceCode(), userAccount);
 	}
 
 	@Override
@@ -760,10 +757,12 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 			randomUserAccount());
 	}
 
-	private UserAccount _addAccountUser(Long accountId, UserAccount userAccount)
+	private UserAccount _addAccountUserAccount(
+			Long accountId, UserAccount userAccount)
 		throws Exception {
 
-		return userAccountResource.postAccountUser(accountId, userAccount);
+		return userAccountResource.postAccountUserAccount(
+			accountId, userAccount);
 	}
 
 	private UserAccount _addUserAccount(long siteId, UserAccount userAccount)


### PR DESCRIPTION
This is an update for [LPS-130793](https://issues.liferay.com/browse/LPS-130793).<br/><br/>/cc @pei-jung @alee8888 @ChrisKian @patriciajeanperez @lr-leo

/cc @luca-pellizzon @marco-leo I did not see any current usages of the changed endpoints in portal that needed updating. Will you please check any in-progress work that may be affected by this change? 

The main difference is this: 
• account-user -> user-account (endpoint path)
• accountUser -> userAccount (GraphQL resource name)
• AccountUser -> AccountUserAccount (GraphQL resource name)

-------------

Edit: additional changes pushed:
• UserAssociation -> UserAccountAssociation (GraphQL resource name)
• AccountRole -> AccountAccountRole (GraphQL resource name)