### PR TITLE
[TS] LPS-137164

### DIFF
--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/ContactBatchReindexerImpl.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/ContactBatchReindexerImpl.java
@@ -37,9 +37,10 @@ public class ContactBatchReindexerImpl implements ContactBatchReindexer {
 
 		batchIndexingActionable.setAddCriteriaMethod(
 			dynamicQuery -> {
-				Property userIdProperty = PropertyFactoryUtil.forName("userId");
+				Property classPKProperty = PropertyFactoryUtil.forName(
+					"classPK");
 
-				dynamicQuery.add(userIdProperty.eq(userId));
+				dynamicQuery.add(classPKProperty.eq(userId));
 			});
 		batchIndexingActionable.setCompanyId(companyId);
 		batchIndexingActionable.setPerformActionMethod(

--- a/modules/apps/users-admin/users-admin-test/build.gradle
+++ b/modules/apps/users-admin/users-admin-test/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	testIntegrationCompile project(":apps:export-import:export-import-test-util")
 	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:portal-search:portal-search-api")
+	testIntegrationCompile project(":apps:portal-search:portal-search-spi")
 	testIntegrationCompile project(":apps:portal-search:portal-search-test-util")
 	testIntegrationCompile project(":apps:users-admin:users-admin-api")
 	testIntegrationCompile project(":apps:users-admin:users-admin-test-util")


### PR DESCRIPTION
As far as I can see the creating user information (`userId`, `userName`) does not change within the Contact table when the creating user is modified. The only details that change is the user's information who is associated with that contact (`emailAddress`, `firstName`, etc).

If this assumption is incorrect then please let me know so I can pass that information along to the client to better explain why all of the contact models need to be updated when a single user is reindexed.

Please let me know if there are any questions.