### PR TITLE
LPS-136288 Profile picture is missing server side validation on the size

### DIFF
--- a/modules/apps/image-uploader/image-uploader-web/build.gradle
+++ b/modules/apps/image-uploader/image-uploader-web/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
+	compileOnly project(":apps:users-admin:users-admin-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")


### PR DESCRIPTION
This is an update for [LPS-136288](https://issues.liferay.com/browse/LPS-136288).<br/><br/>/cc @pei-jung @alee8888 @ChrisKian @patriciajeanperez @lr-leo

cc @IstvanD this adjusts the solution per Brian's request here: https://github.com/brianchandotcom/liferay-portal/pull/105470#issuecomment-897759409.

Since we now have a somewhat reliable way to determine that we're dealing with a user portrait, we can just inline this logic in the MVCActionCommand.