### PR TITLE
LPS-139045 com.liferay.commerce.account.service upgrade - Could not parse column as time - MariaDB

### DIFF
--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v7_0_0/CommerceAddressUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v7_0_0/CommerceAddressUpgradeProcess.java
@@ -67,8 +67,8 @@ public class CommerceAddressUpgradeProcess extends UpgradeProcess {
 				address.setCompanyId(resultSet.getLong("companyId"));
 				address.setUserId(resultSet.getLong("userId"));
 				address.setUserName(resultSet.getString("userName"));
-				address.setCreateDate(resultSet.getTime("createDate"));
-				address.setModifiedDate(resultSet.getTime("modifiedDate"));
+				address.setCreateDate(resultSet.getTimestamp("createDate"));
+				address.setModifiedDate(resultSet.getTimestamp("modifiedDate"));
 				address.setClassNameId(resultSet.getLong("classNameId"));
 				address.setClassPK(resultSet.getLong("classPK"));
 				address.setCountryId(resultSet.getLong("countryId"));


### PR DESCRIPTION
This is an update for [LPS-139045](https://issues.liferay.com/browse/LPS-139045).<br/><br/>/cc @pei-jung @alee8888 @ChrisKian @patriciajeanperez @lr-leo @brunoquei2105 @erickmonteiroo