### PR TITLE
master | LPS-143296 

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1269,11 +1269,11 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 				userLdapAttributes, "modifyTimestamp");
 
 			try {
+				updateExpandoAttributes(ldapImportContext, user, ldapUser);
+
 				user = updateUser(
 					ldapImportContext, ldapUser, user, password,
 					modifyTimestamp, isNew);
-
-				updateExpandoAttributes(ldapImportContext, user, ldapUser);
 
 				ldapImportContext.addImportedUserId(
 					fullUserDN, user.getUserId());


### PR DESCRIPTION
Hi team,

This change avoids a problem in the user indexation after LDAP synchronizations. The sync problem is related to the expando attributes. If a expando value is modifed, the new value is set in the DDBB but isn't indexed.

The method that makes the indexation is:

```
user = updateUser(
					ldapImportContext, ldapUser, user, password,
					modifyTimestamp, isNew);
```
If the expando values are saved after that, during the user indexation, the expando attributes contributor gets the old values and the indexation is done wrongly. 

I think that the order change in the operations shouldn't be problematic. In users additions, new users are created in line 1262, so when the expando values are updated, the user always exists in Liferay.

If you have any doubts about the PR, please let me know.

Regards.