### PR TITLE
LPS-138931 Changing pagination in a different page will hide roles

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
@@ -28,6 +28,7 @@ import com.liferay.petra.sql.dsl.query.FromStep;
 import com.liferay.petra.sql.dsl.query.GroupByStep;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
+import com.liferay.portal.kernel.dao.search.SearchPaginationUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -280,6 +281,16 @@ public class AccountRoleLocalServiceImpl
 			params = new LinkedHashMap<>();
 		}
 
+		int total = accountRoleLocalService.dslQueryCount(
+			_getGroupByStep(
+				accountEntryIds, companyId,
+				DSLQueryFactoryUtil.countDistinct(
+					AccountRoleTable.INSTANCE.roleId),
+				keywords, params));
+
+		int[] startAndEnd = SearchPaginationUtil.calculateStartAndEnd(
+			start, end, total);
+
 		return new BaseModelSearchResult<>(
 			accountRoleLocalService.dslQuery(
 				_getGroupByStep(
@@ -289,14 +300,9 @@ public class AccountRoleLocalServiceImpl
 				).orderBy(
 					RoleTable.INSTANCE, orderByComparator
 				).limit(
-					start, end
+					startAndEnd[0], startAndEnd[1]
 				)),
-			accountRoleLocalService.dslQueryCount(
-				_getGroupByStep(
-					accountEntryIds, companyId,
-					DSLQueryFactoryUtil.countDistinct(
-						AccountRoleTable.INSTANCE.roleId),
-					keywords, params)));
+			total);
 	}
 
 	@Override

--- a/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributor.java
+++ b/modules/apps/roles/roles-admin-api/src/main/java/com/liferay/roles/admin/role/type/contributor/RoleTypeContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.roles.admin.role.type.contributor;
 
+import com.liferay.portal.kernel.dao.search.SearchPaginationUtil;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
@@ -179,12 +180,17 @@ public interface RoleTypeContributor {
 				"classNameId", PortalUtil.getClassNameId(getClassName()));
 		}
 
+		int total = RoleServiceUtil.searchCount(
+			companyId, keywords, new Integer[] {getType()}, params);
+
+		int[] startAndEnd = SearchPaginationUtil.calculateStartAndEnd(
+			start, end, total);
+
 		return new BaseModelSearchResult<>(
 			RoleServiceUtil.search(
-				companyId, keywords, new Integer[] {getType()}, params, start,
-				end, orderByComparator),
-			RoleServiceUtil.searchCount(
-				companyId, keywords, new Integer[] {getType()}, params));
+				companyId, keywords, new Integer[] {getType()}, params,
+				startAndEnd[0], startAndEnd[1], orderByComparator),
+			total);
 	}
 
 }


### PR DESCRIPTION
This is an update for [LPS-138931](https://issues.liferay.com/browse/LPS-138931).

@pei-jung will you take a look at these changes to make sure I didn't miss anything?

I think the takeaway from this bug is that any method that returns a `BaseModelSearchResult` and is not using indexer search should probably apply a similar fix to this one. Let's keep an eye out for other potential issues along the same lines.

/cc @pei-jung @alee8888 @ChrisKian @patriciajeanperez @lr-leo @erickmonteiroo