### PR TITLE
LPS-143549 Modify the logic so that we always call

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/search/test/DepotEntrySearchTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/search/test/DepotEntrySearchTest.java
@@ -31,7 +31,7 @@ import com.liferay.portal.kernel.search.SearchResultUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
@@ -46,7 +46,6 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -60,6 +59,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Alejandro Tardín
  */
+@DataGuard(scope = DataGuard.Scope.METHOD)
 @RunWith(Arquillian.class)
 @Sync
 public class DepotEntrySearchTest {
@@ -235,20 +235,13 @@ public class DepotEntrySearchTest {
 	public SearchTestRule searchTestRule = new SearchTestRule();
 
 	private DepotEntry _addDepotEntry(User user, String name) throws Exception {
-		DepotEntry depotEntry = _depotEntryService.addDepotEntry(
+		return _depotEntryService.addDepotEntry(
 			Collections.singletonMap(LocaleUtil.getDefault(), name),
 			Collections.singletonMap(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId(), user.getUserId()));
-
-		_depotEntries.add(depotEntry);
-
-		return depotEntry;
 	}
-
-	@DeleteAfterTestRun
-	private final List<DepotEntry> _depotEntries = new ArrayList<>();
 
 	@Inject
 	private DepotEntryService _depotEntryService;

--- a/portal-impl/src/com/liferay/portal/security/permission/UserBagFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/UserBagFactoryImpl.java
@@ -76,30 +76,29 @@ public class UserBagFactoryImpl implements UserBagFactory {
 			allGroupIds.add(groupId);
 		}
 
-		long[] userGroupIds = null;
+		long[] userGroupIds = UserLocalServiceUtil.getGroupPrimaryKeys(userId);
 
-		if (userOrgs.isEmpty() && userUserGroups.isEmpty()) {
-			userGroupIds = UserLocalServiceUtil.getGroupPrimaryKeys(userId);
+		Set<Long> userGroupIdsSet = new HashSet<>();
 
-			for (long userGroupId : userGroupIds) {
-				allGroupIds.add(userGroupId);
-			}
+		for (long userGroupId : userGroupIds) {
+			userGroupIdsSet.add(userGroupId);
+
+			allGroupIds.add(userGroupId);
 		}
-		else {
+
+		if (!userOrgs.isEmpty() || !userUserGroups.isEmpty()) {
 			List<Group> userGroups = GroupLocalServiceUtil.getUserGroups(
 				userId, true);
 
-			userGroupIds = new long[userGroups.size()];
-
-			for (int i = 0; i < userGroups.size(); i++) {
-				Group userGroup = userGroups.get(i);
-
+			for (Group userGroup : userGroups) {
 				long groupId = userGroup.getGroupId();
 
-				userGroupIds[i] = groupId;
+				userGroupIdsSet.add(groupId);
 
 				allGroupIds.add(groupId);
 			}
+
+			userGroupIds = ArrayUtil.toLongArray(userGroupIdsSet);
 		}
 
 		if (allGroupIds.isEmpty()) {


### PR DESCRIPTION
Hey @drewbrokke,

This wasn't one of the fixes you suggested, but it should be fairly straightforward and should be regression-proof. Basically the change in logic is this:

**Before This Change**
No Orgs/UserGroups: `UserLocalServiceUtil.getGroupPrimaryKeys(userId)`
Else: `GroupLocalServiceUtil.getUserGroups`

**After This Change**
No Orgs/UserGroups: `UserLocalServiceUtil.getGroupPrimaryKeys(userId)`
Else: `GroupLocalServiceUtil.getUserGroups UNION UserLocalServiceUtil.getGroupPrimaryKeys(userId)`

So the only difference is now in the else case, where the user has at least 1 org or user group, we are UNIONING the result of the else case with the result of the No Orgs/UserGroups case.

Let me know what you think of this.