### PR TITLE
LPS-145148 Introduce a creation method to ensure correctly re-calculated start and end values when constructing a BaseModelSearchResult

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleLocalServiceImpl.java
@@ -28,7 +28,6 @@ import com.liferay.petra.sql.dsl.query.FromStep;
 import com.liferay.petra.sql.dsl.query.GroupByStep;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
-import com.liferay.portal.kernel.dao.search.SearchPaginationUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -277,32 +276,33 @@ public class AccountRoleLocalServiceImpl
 		LinkedHashMap<String, Object> params, int start, int end,
 		OrderByComparator<?> orderByComparator) {
 
+		LinkedHashMap<String, Object> searchParams;
+
 		if (params == null) {
-			params = new LinkedHashMap<>();
+			searchParams = new LinkedHashMap<>();
+		}
+		else {
+			searchParams = params;
 		}
 
-		int total = accountRoleLocalService.dslQueryCount(
-			_getGroupByStep(
-				accountEntryIds, companyId,
-				DSLQueryFactoryUtil.countDistinct(
-					AccountRoleTable.INSTANCE.roleId),
-				keywords, params));
-
-		int[] startAndEnd = SearchPaginationUtil.calculateStartAndEnd(
-			start, end, total);
-
-		return new BaseModelSearchResult<>(
-			accountRoleLocalService.dslQuery(
+		return BaseModelSearchResult.createWithStartAndEnd(
+			startAndEnd -> accountRoleLocalService.dslQuery(
 				_getGroupByStep(
 					accountEntryIds, companyId,
 					DSLQueryFactoryUtil.select(AccountRoleTable.INSTANCE),
-					keywords, params
+					keywords, searchParams
 				).orderBy(
 					RoleTable.INSTANCE, orderByComparator
 				).limit(
-					startAndEnd[0], startAndEnd[1]
+					startAndEnd.getStart(), startAndEnd.getEnd()
 				)),
-			total);
+			accountRoleLocalService.dslQueryCount(
+				_getGroupByStep(
+					accountEntryIds, companyId,
+					DSLQueryFactoryUtil.countDistinct(
+						AccountRoleTable.INSTANCE.roleId),
+					keywords, searchParams)),
+			start, end);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
@@ -230,21 +230,22 @@ public class CountryLocalServiceImpl extends CountryLocalServiceBaseImpl {
 			OrderByComparator<Country> orderByComparator)
 		throws PortalException {
 
-		return new BaseModelSearchResult<>(
-			countryPersistence.dslQuery(
+		return BaseModelSearchResult.unsafeCreateWithStartAndEnd(
+			startAndEnd -> countryPersistence.dslQuery(
 				_getGroupByStep(
 					DSLQueryFactoryUtil.selectDistinct(CountryTable.INSTANCE),
 					companyId, active, keywords
 				).orderBy(
 					CountryTable.INSTANCE, orderByComparator
 				).limit(
-					start, end
+					startAndEnd.getStart(), startAndEnd.getEnd()
 				)),
 			countryPersistence.dslQueryCount(
 				_getGroupByStep(
 					DSLQueryFactoryUtil.countDistinct(
 						CountryTable.INSTANCE.countryId),
-					companyId, active, keywords)));
+					companyId, active, keywords)),
+			start, end);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 11.1.0


### PR DESCRIPTION
This is an update for [LPS-145148](https://issues.liferay.com/browse/LPS-145148).<br/><br/>/cc @pei-jung @alee8888 @ChrisKian @patriciajeanperez @lr-leo @erickmonteiroo