### PR TITLE
LPS-146707 Filtering by Override and searching for translations will cause portlet to be temporarily unavailable

### DIFF
--- a/modules/apps/portal-language/portal-language-override-web/src/main/java/com/liferay/portal/language/override/web/internal/display/context/ViewDisplayContextFactory.java
+++ b/modules/apps/portal-language/portal-language-override-web/src/main/java/com/liferay/portal/language/override/web/internal/display/context/ViewDisplayContextFactory.java
@@ -302,7 +302,7 @@ public class ViewDisplayContextFactory {
 
 		searchContainer.setResultsAndTotal(
 			() -> languageItemDisplays.subList(
-				searchContainer.getStart(), searchContainer.getEnd()),
+				searchContainer.getStart(), searchContainer.getResultEnd()),
 			languageItemDisplays.size());
 	}
 


### PR DESCRIPTION
This is an update for [LPS-146707](https://issues.liferay.com/browse/LPS-146707).<br/><br/>/cc @pei-jung @alee8888 @ChrisKian @patriciajeanperez @lr-leo @erickmonteiroo

After a searchContainer's `total` is set, the `end` field does _not_ get fully recalculated, but rather `resultEnd`.