### PR TITLE
LPS-140939 As a remote System Admin, I can set the email and name of the admin when creating a virtual instance

### DIFF
--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/dto/v1_0/PortalInstance.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/dto/v1_0/PortalInstance.java
@@ -114,7 +114,7 @@ public class PortalInstance implements Serializable {
 	@GraphQLField(
 		description = "The portal instance's administrator. This field is optional and is only used in the portal instance creation."
 	)
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	protected Admin admin;
 
 	@Schema(description = "internal unique key.")

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/resources/com/liferay/headless/portal/instances/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/resources/com/liferay/headless/portal/instances/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.2.1

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
@@ -35,6 +35,7 @@ components:
                     description:
                         The portal instance's administrator. This field is optional and is only used in the portal
                         instance creation.
+                    writeOnly: true
                 companyId:
                     description:
                         internal unique key.


### PR DESCRIPTION
This is an update for [LPS-140939](https://issues.liferay.com/browse/LPS-140939).<br/><br/>/cc @pei-jung @alee8888 @ChrisKian @patriciajeanperez @lr-leo @erickmonteiroo

This is a follow-up pull to add the `writeOnly` attribute to the admin info. No functional changes, just a more expressive schema.