### PR TITLE
LPS-146724 Intermittent failure in testSearchAccountGroups

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/index/contributor/AccountGroupModelDocumentContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/index/contributor/AccountGroupModelDocumentContributor.java
@@ -37,6 +37,8 @@ public class AccountGroupModelDocumentContributor
 		document.addText(Field.DESCRIPTION, accountGroup.getDescription());
 		document.addText(Field.NAME, accountGroup.getName());
 		document.addKeyword(Field.TYPE, accountGroup.getType());
+		document.addKeyword(
+			"defaultAccountGroup", accountGroup.isDefaultAccountGroup());
 	}
 
 }

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/query/contributor/AccountGroupModelPreFilterContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/query/contributor/AccountGroupModelPreFilterContributor.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.account.internal.search.spi.model.query.contributor;
+
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Erick Monteiro
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.account.model.AccountGroup",
+	service = ModelPreFilterContributor.class
+)
+public class AccountGroupModelPreFilterContributor
+	implements ModelPreFilterContributor {
+
+	@Override
+	public void contribute(
+		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
+		SearchContext searchContext) {
+
+		booleanFilter.addRequiredTerm("defaultAccountGroup", false);
+	}
+
+}

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountGroupLocalServiceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountGroupLocalServiceTest.java
@@ -145,13 +145,16 @@ public class AccountGroupLocalServiceTest {
 		_addAccountGroup();
 
 		OrderByComparator<AccountGroup> orderByComparator =
-			OrderByComparatorFactoryUtil.create(
-				"AccountGroup", "createDate", true);
+			OrderByComparatorFactoryUtil.create("AccountGroup", "name", true);
 
 		List<AccountGroup> expectedAccountGroups =
 			_accountGroupLocalService.getAccountGroups(
 				TestPropsValues.getCompanyId(), QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS, orderByComparator);
+
+		expectedAccountGroups = ListUtil.filter(
+			expectedAccountGroups,
+			accountGroup -> !accountGroup.isDefaultAccountGroup());
 
 		BaseModelSearchResult<AccountGroup> baseModelSearchResult =
 			_accountGroupLocalService.searchAccountGroups(

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountGroupServiceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountGroupServiceTest.java
@@ -135,6 +135,10 @@ public class AccountGroupServiceTest {
 				_user.getCompanyId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 				orderByComparator);
 
+		expectedAccountGroups = ListUtil.filter(
+			expectedAccountGroups,
+			accountGroup -> !accountGroup.isDefaultAccountGroup());
+
 		Assert.assertEquals(
 			expectedAccountGroups.size(), baseModelSearchResult.getLength());
 		Assert.assertEquals(


### PR DESCRIPTION
This pull causes changes to the Account Groups UI. After this, the Guest Account Group will no longer be visible in the account groups list, as intended in [LPS-123926](https://issues.liferay.com/browse/LPS-123926).

@drewbrokke @pei-jung @patriciajeanperez @epark18 @Sharryxue