### PR TITLE
[TS] LPS-147639 Make profile image responsive and set margin on select button

### DIFF
--- a/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/upload_image.jsp
+++ b/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/upload_image.jsp
@@ -94,7 +94,7 @@ String tempImageFileName = ParamUtil.getString(request, "tempImageFileName");
 							</h4>
 
 							<div class="lfr-change-logo lfr-portrait-preview" id="<portlet:namespace />portraitPreview">
-								<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="image-preview" />" class="lfr-portrait-preview-img" id="<portlet:namespace />portraitPreviewImg" src="<%= HtmlUtil.escape(currentImageURL) %>" />
+								<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="image-preview" />" class="img-fluid lfr-portrait-preview-img" id="<portlet:namespace />portraitPreviewImg" src="<%= HtmlUtil.escape(currentImageURL) %>" />
 							</div>
 
 							<c:if test='<%= Validator.isNull(currentImageURL) || currentImageURL.contains("/spacer.png") %>'>

--- a/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/upload_image.jsp
+++ b/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/upload_image.jsp
@@ -104,7 +104,7 @@ String tempImageFileName = ParamUtil.getString(request, "tempImageFileName");
 							</c:if>
 
 							<div class="button-holder">
-								<label class="btn btn-secondary" for="<portlet:namespace />fileName" id="<portlet:namespace />uploadImage" tabindex="0"><liferay-ui:message key="select" /></label>
+								<label class="btn btn-secondary mt-2" for="<portlet:namespace />fileName" id="<portlet:namespace />uploadImage" tabindex="0"><liferay-ui:message key="select" /></label>
 
 								<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) || windowState.equals(LiferayWindowState.POP_UP) %>" cssClass="hide" label="" name="fileName" type="file">
 									<aui:validator name="acceptFiles">


### PR DESCRIPTION
Hi Team,

LPS: https://issues.liferay.com/browse/LPS-147639

The image is not responsive when selecting it to upload on a mobile viewport and there is no margin above the select button.
![NotResponsive](https://user-images.githubusercontent.com/97447507/155090741-dd978946-4f24-4934-b1b0-e7407db6f235.gif)

Fix:
The img-fluid class is applied on the image element to make it responsive, and the mt-2 class is applied to add a top margin on the select button.
![Responsive](https://user-images.githubusercontent.com/97447507/155090758-9524754a-716d-4414-9765-d15a957602a0.gif)

Could you please review it?
Thank you!