### PR TITLE
LPS-148702 Fix ResourcePermission deletion for Announcements and Roles - LPS-145396 Subtask

### DIFF
--- a/modules/apps/announcements/announcements-uad/src/main/java/com/liferay/announcements/uad/anonymizer/BaseAnnouncementsEntryUADAnonymizer.java
+++ b/modules/apps/announcements/announcements-uad/src/main/java/com/liferay/announcements/uad/anonymizer/BaseAnnouncementsEntryUADAnonymizer.java
@@ -52,9 +52,10 @@ public abstract class BaseAnnouncementsEntryUADAnonymizer
 	}
 
 	@Override
-	public void delete(AnnouncementsEntry announcementsEntry) {
-		announcementsEntryLocalService.deleteAnnouncementsEntry(
-			announcementsEntry);
+	public void delete(AnnouncementsEntry announcementsEntry)
+		throws PortalException {
+
+		announcementsEntryLocalService.deleteEntry(announcementsEntry);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -461,14 +461,9 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 				resourcePermission);
 		}
 
-		String className = role.getClassName();
-		long classNameId = role.getClassNameId();
-
-		if ((classNameId <= 0) || className.equals(Role.class.getName())) {
-			_resourceLocalService.deleteResource(
-				role.getCompanyId(), Role.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL, role.getRoleId());
-		}
+		_resourceLocalService.deleteResource(
+			role.getCompanyId(), Role.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, role.getRoleId());
 
 		if ((role.getType() == RoleConstants.TYPE_DEPOT) ||
 			(role.getType() == RoleConstants.TYPE_ORGANIZATION) ||


### PR DESCRIPTION
When we delete some types of objects in Liferay, we are not deleting their ResourcePermission records, leaving some database wrong references.

For more information see parent LPS-145396

This subtask addresses the issue for User and System Mngt. team code

/cc @tinatian
