### PR TITLE
LPS-148152 Unable to select account for account use via user admin

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyAccountPortlet.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyAccountPortlet.java
@@ -55,7 +55,8 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.init-param.template-path=/META-INF/resources/",
 		"javax.portlet.name=" + UsersAdminPortletKeys.MY_ACCOUNT,
 		"javax.portlet.resource-bundle=content.Language",
-		"javax.portlet.security-role-ref=administrator"
+		"javax.portlet.security-role-ref=administrator",
+		"javax.portlet.version=3.0"
 	},
 	service = Portlet.class
 )


### PR DESCRIPTION
This is a follow up commit. For some reason the fix only works if we add the `javax.portlet.version=3.0` in both `MyAccountPortlet.java` and `UsersAdminPortlet.java`

@drewbrokke @pei-jung @epark18
