### PR TITLE
[TS] LPS-153995

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -442,13 +442,13 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			}
 		}
 
-		if (roleIdSet.isEmpty()) {
-			return false;
-		}
-
 		long[] roleIds = ArrayUtil.toArray(roleIdSet.toArray(new Long[0]));
 
 		roleIds = UsersAdminUtil.addRequiredRoles(user, roleIds);
+
+		if (ArrayUtil.containsAll(userRoleIds, roleIds)) {
+			return false;
+		}
 
 		userPersistence.addRoles(userId, roleIds);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-153995

According to [this comment](https://github.com/liferay-usm/liferay-portal/pull/494#issuecomment-1076695231), the "User" role should always be included with the user as a default association, even if explicitly removed.  It's possible with the inclusion of LPS-134096 to exclude the "User" role.

Please let me know if you have any questions, thanks!