### PR TITLE
LPS-154973 Update permission on bulk for several documents

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
@@ -71,9 +71,9 @@ const SearchControls = ({
 
 				{searchData &&
 					Object.keys(searchData).map((key) =>
-						searchData[key].map((value) => (
+						searchData[key].map((value, index) => (
 							<ClayInput
-								key={key}
+								key={`${key}${index}`}
 								name={key}
 								type="hidden"
 								value={value}

--- a/modules/apps/portlet-configuration/portlet-configuration-web/build.gradle
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":apps:petra:petra-portlet-url-builder")
 	compileOnly project(":apps:roles:roles-admin-api")

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
@@ -69,6 +69,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -712,6 +713,32 @@ public class PortletConfigurationPermissionsDisplayContext {
 		).setWindowState(
 			LiferayWindowState.POP_UP
 		).buildPortletURL();
+	}
+
+	public boolean isActionActive(
+		String action, Map<String, List<String>> resourceActionsMap) {
+
+		List<String> resourceActions = resourceActionsMap.get(action);
+
+		if (ListUtil.isNull(resourceActions)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	public boolean isActionCommonToAllResources(
+		String action, Map<String, List<String>> resourceActionsMap) {
+
+		List<String> resourceActions = resourceActionsMap.get(action);
+
+		if (ListUtil.isNull(resourceActions) ||
+			(resourceActions.size() < _resources.size())) {
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private int[] _getGroupRoleTypes(Group group, int[] defaultRoleTypes) {

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
@@ -295,33 +295,16 @@ public class PortletConfigurationPermissionsDisplayContext {
 		return _modelResourceDescription;
 	}
 
-	public Resource getResource() throws PortalException {
-		if (_resource != null) {
-			return _resource;
+	public String getResourceName() throws PortalException {
+		List<Resource> resources = getResources();
+
+		if (ListUtil.isEmpty(resources)) {
+			return StringPool.BLANK;
 		}
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)_httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
+		Resource resource = resources.get(0);
 
-		int count =
-			ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
-				themeDisplay.getCompanyId(), getSelResource(),
-				ResourceConstants.SCOPE_INDIVIDUAL, getResourcePrimKey());
-
-		if (count == 0) {
-			boolean portletActions = Validator.isNull(getModelResource());
-
-			ResourceLocalServiceUtil.addResources(
-				themeDisplay.getCompanyId(), getGroupId(), 0, getSelResource(),
-				getResourcePrimKey(), portletActions, true, true);
-		}
-
-		_resource = ResourceLocalServiceUtil.getResource(
-			themeDisplay.getCompanyId(), getSelResource(),
-			ResourceConstants.SCOPE_INDIVIDUAL, getResourcePrimKey());
-
-		return _resource;
+		return resource.getName();
 	}
 
 	public String getResourcePrimKey() throws ResourcePrimKeyException {
@@ -871,7 +854,6 @@ public class PortletConfigurationPermissionsDisplayContext {
 	private String _modelResourceDescription;
 	private String _portletResource;
 	private final RenderRequest _renderRequest;
-	private Resource _resource;
 	private Long _resourceGroupId;
 	private String[] _resourcePrimKeys;
 	private final List<Resource> _resources = new ArrayList<>();

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
@@ -570,27 +570,48 @@ public class PortletConfigurationPortlet extends MVCPortlet {
 			if (GetterUtil.getBoolean(
 					PropsUtil.get("feature.flag.LPS-87806"))) {
 
-				_resourcePermissionService.setIndividualResourcePermissions(
-					resourceGroupId, themeDisplay.getCompanyId(), selResource,
-					resourcePrimKey,
-					_getRoleIdsToActionIdsResourcePrimKey(
-						themeDisplay.getCompanyId(), resourcePrimKey, roleIds,
-						roleIdsToActionIds, selResource, actionRequest));
+				if (_serviceTrackerMap.containsKey(selResource)) {
+					_resourcePermissionService.setIndividualResourcePermissions(
+						resourceGroupId, themeDisplay.getCompanyId(),
+						selResource, resourcePrimKey,
+						_getRoleIdsToActionIdsResourcePrimKey(
+							themeDisplay.getCompanyId(), resourcePrimKey,
+							roleIds, roleIdsToActionIds, selResource,
+							actionRequest));
+				}
+				else {
+					try (SafeCloseable safeCloseable =
+							CTCollectionThreadLocal.
+								setProductionModeWithSafeCloseable()) {
+
+						_resourcePermissionService.
+							setIndividualResourcePermissions(
+								resourceGroupId, themeDisplay.getCompanyId(),
+								selResource, resourcePrimKey,
+								_getRoleIdsToActionIdsResourcePrimKey(
+									themeDisplay.getCompanyId(),
+									resourcePrimKey, roleIds,
+									roleIdsToActionIds, selResource,
+									actionRequest));
+					}
+				}
 			}
 			else {
 				if (_serviceTrackerMap.containsKey(selResource)) {
 					_resourcePermissionService.setIndividualResourcePermissions(
-						resourceGroupId, themeDisplay.getCompanyId(), selResource,
-						resourcePrimKey, roleIdsToActionIds);
+						resourceGroupId, themeDisplay.getCompanyId(),
+						selResource, resourcePrimKey, roleIdsToActionIds);
 				}
 				else {
 					try (SafeCloseable safeCloseable =
-							 CTCollectionThreadLocal.
-								 setProductionModeWithSafeCloseable()) {
+							CTCollectionThreadLocal.
+								setProductionModeWithSafeCloseable()) {
 
-						_resourcePermissionService.setIndividualResourcePermissions(
-							resourceGroupId, themeDisplay.getCompanyId(), selResource,
-							resourcePrimKey, roleIdsToActionIds);
+						_resourcePermissionService.
+							setIndividualResourcePermissions(
+								resourceGroupId, themeDisplay.getCompanyId(),
+								selResource, resourcePrimKey,
+								roleIdsToActionIds);
 					}
 				}
 			}

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -97,34 +97,16 @@ String resourceName = portletConfigurationPermissionsDisplayContext.getResourceN
 					List<String> currentGroupTemplateActions = new ArrayList<String>();
 					List<String> currentCompanyActions = new ArrayList<String>();
 
-					Map<String, List<String>> resourceActionsMap = new HashMap<>();
-
-					if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-87806"))) {
-						resourceActionsMap = portletConfigurationPermissionsDisplayContext.populateResourcePermissionActionIds(portletConfigurationPermissionsDisplayContext.getGroupId(), role, resources, portletConfigurationPermissionsDisplayContext.getActions(), currentIndividualActions, currentGroupActions, currentGroupTemplateActions, currentCompanyActions);
-					}
-					else {
-						ResourcePermissionUtil.populateResourcePermissionActionIds(portletConfigurationPermissionsDisplayContext.getGroupId(), role, resource, portletConfigurationPermissionsDisplayContext.getActions(), currentIndividualActions, currentGroupActions, currentGroupTemplateActions, currentCompanyActions);
-					}
+					Map<String, List<String>> resourceActionsMap = portletConfigurationPermissionsDisplayContext.populateResourcePermissionActionIds(portletConfigurationPermissionsDisplayContext.getGroupId(), role, resources, portletConfigurationPermissionsDisplayContext.getActions(), currentIndividualActions, currentGroupActions, currentGroupTemplateActions, currentCompanyActions);
 
 					for (String action : portletConfigurationPermissionsDisplayContext.getActions()) {
 						if (action.equals(ActionKeys.ACCESS_IN_CONTROL_PANEL)) {
 							continue;
 						}
 
-						boolean isActionActive = portletConfigurationPermissionsDisplayContext.isActionActive(action, resourceActionsMap);
-						boolean checked = false;
-						boolean indeterminate = false;
+						boolean checked = portletConfigurationPermissionsDisplayContext.isChecked(action, currentIndividualActions, currentGroupActions, currentGroupTemplateActions, currentCompanyActions, resourceActionsMap);
 
-						if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-87806"))) {
-							checked = portletConfigurationPermissionsDisplayContext.isActionCommonToAllResources(action, resourceActionsMap);
-
-							indeterminate = (resources.size() > 1) && !checked && isActionActive;
-						}
-						else {
-							if (currentIndividualActions.contains(action) || currentGroupActions.contains(action) || currentGroupTemplateActions.contains(action) || currentCompanyActions.contains(action)) {
-								checked = true;
-							}
-						}
+						boolean indeterminate = portletConfigurationPermissionsDisplayContext.isIndeterminate(action, checked, resourceActionsMap);
 
 						String preselectedMsg = StringPool.BLANK;
 

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -135,6 +135,10 @@ String resourceName = portletConfigurationPermissionsDisplayContext.getResourceN
 							}
 
 							dataMessage = HtmlUtil.escapeAttribute(LanguageUtil.format(request, preselectedMsg, new Object[] {role.getTitle(locale), _getActionLabel(request, resourceName, action), type, HtmlUtil.escape(portletConfigurationPermissionsDisplayContext.getGroupDescriptiveName())}, false));
+
+							if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-87806"))) {
+								disabled = true;
+							}
 						}
 
 						String actionSeparator = Validator.isNotNull(preselectedMsg) ? ActionUtil.PRESELECTED : ActionUtil.ACTION;
@@ -155,7 +159,7 @@ String resourceName = portletConfigurationPermissionsDisplayContext.getResourceN
 											<label>
 												<input
 													<%= (checked || indeterminate) ? "checked" : StringPool.BLANK %>
-													<%= (disabled || Validator.isNotNull(preselectedMsg)) ? "disabled" : StringPool.BLANK %>
+													<%= disabled ? "disabled" : StringPool.BLANK %>
 													<%= indeterminate ? "value=\"indeterminate\"" : StringPool.BLANK %>
 													class="custom-control-input"
 													name="<%= liferayPortletResponse.getNamespace() + role.getRoleId() + actionSeparator + action %>"
@@ -171,7 +175,7 @@ String resourceName = portletConfigurationPermissionsDisplayContext.getResourceN
 												HashMapBuilder.<String, Object>put(
 													"checked", checked
 												).put(
-													"disabled", disabled || Validator.isNotNull(preselectedMsg)
+													"disabled", disabled
 												).put(
 													"indeterminate", indeterminate
 												).put(

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -173,6 +173,20 @@ String resourceName = resource.getName();
 							<c:choose>
 								<c:when test='<%= GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-87806")) %>'>
 									<div>
+										<div class="custom-checkbox custom-control custom-control-inline">
+											<label>
+												<input
+													<%= (checked || indeterminate) ? "checked" : StringPool.BLANK %>
+													<%= (disabled || Validator.isNotNull(preselectedMsg)) ? "disabled" : StringPool.BLANK %>
+													<%= indeterminate ? "value=\"indeterminate\"" : StringPool.BLANK %>
+													class="custom-control-input"
+													name="<%= liferayPortletResponse.getNamespace() + role.getRoleId() + actionSeparator + action %>"
+													type="checkbox"
+												/><span class="custom-control-label"></span
+											>
+											</label>
+										</div>
+
 										<react:component
 											module="js/PermissionsCheckbox"
 											props='<%=

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -21,8 +21,6 @@ RoleTypeContributorProvider roleTypeContributorProvider = (RoleTypeContributorPr
 
 PortletConfigurationPermissionsDisplayContext portletConfigurationPermissionsDisplayContext = new PortletConfigurationPermissionsDisplayContext(request, renderRequest, roleTypeContributorProvider);
 
-Resource resource = portletConfigurationPermissionsDisplayContext.getResource();
-
 List<Resource> resources = portletConfigurationPermissionsDisplayContext.getResources();
 
 SearchContainer<Role> roleSearchContainer = portletConfigurationPermissionsDisplayContext.getRoleSearchContainer();
@@ -32,7 +30,7 @@ if (Validator.isNotNull(portletConfigurationPermissionsDisplayContext.getModelRe
 	PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "permissions"), currentURL);
 }
 
-String resourceName = resource.getName();
+String resourceName = portletConfigurationPermissionsDisplayContext.getResourceName();
 %>
 
 <div class="edit-permissions portlet-configuration-edit-permissions">

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -44,8 +44,6 @@ String resourceName = portletConfigurationPermissionsDisplayContext.getResourceN
 		/>
 
 		<aui:form action="<%= portletConfigurationPermissionsDisplayContext.getUpdateRolePermissionsURL() %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm">
-			<aui:input name="resourceId" type="hidden" value="<%= resource.getResourceId() %>" />
-
 			<liferay-ui:search-container
 				searchContainer="<%= roleSearchContainer %>"
 			>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -170,24 +170,35 @@ String resourceName = resource.getName();
 								<input name="<%= liferayPortletResponse.getNamespace() + role.getRoleId() + actionSeparator + action %>" type="hidden" value="<%= true %>" />
 							</c:if>
 
-							<c:if test='<%= GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-87806")) %>'>
-
-								<%
-								boolean allSelected = portletConfigurationPermissionsDisplayContext.isActionCommonToAllResources(action, resourceActionsMap);
-								boolean someSelected = portletConfigurationPermissionsDisplayContext.isActionActive(action, resourceActionsMap);
-								%>
-
-								<aui:script>
-									var checkbox = document.getElementById(
-										'<%= FriendlyURLNormalizerUtil.normalize(role.getName()) + actionSeparator + action %>'
-									);
-									if (<%=resources.size() > 1%> && checkbox && <%=someSelected%>) {
-										checkbox.indeterminate = <%=!allSelected %>;
-									}
-								</aui:script>
-							</c:if>
-
-							<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= Validator.isNotNull(preselectedMsg) ? "lfr-checkbox-preselected lfr-portal-tooltip" : StringPool.BLANK %>" title="<%= dataMessage %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= FriendlyURLNormalizerUtil.normalize(role.getName()) + actionSeparator + action %>" name="<%= liferayPortletResponse.getNamespace() + role.getRoleId() + actionSeparator + action %>" onclick="<%= Validator.isNotNull(preselectedMsg) ? "return false;" : StringPool.BLANK %>" type="checkbox" />
+							<c:choose>
+								<c:when test='<%= GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-87806")) %>'>
+									<div>
+										<react:component
+											module="js/PermissionsCheckbox"
+											props='<%=
+												HashMapBuilder.<String, Object>put(
+													"checked", checked
+												).put(
+													"disabled", disabled || Validator.isNotNull(preselectedMsg)
+												).put(
+													"indeterminate", indeterminate
+												).put(
+													"indeterminateValue", "indeterminate"
+												).put(
+													"inline", true
+												).put(
+													"name", liferayPortletResponse.getNamespace() + role.getRoleId() + actionSeparator + action
+												).put(
+													"title", dataMessage
+												).build()
+											%>'
+										/>
+									</div>
+								</c:when>
+								<c:otherwise>
+									<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= Validator.isNotNull(preselectedMsg) ? "lfr-checkbox-preselected lfr-portal-tooltip" : StringPool.BLANK %>" title="<%= dataMessage %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= FriendlyURLNormalizerUtil.normalize(role.getName()) + actionSeparator + action %>" name="<%= liferayPortletResponse.getNamespace() + role.getRoleId() + actionSeparator + action %>" onclick="<%= Validator.isNotNull(preselectedMsg) ? "return false;" : StringPool.BLANK %>" type="checkbox" />
+								</c:otherwise>
+							</c:choose>
 						</liferay-ui:search-container-column-text>
 
 					<%

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -104,7 +104,7 @@ String resourceName = resource.getName();
 					Map<String, List<String>> resourceActionsMap = new HashMap<>();
 
 					if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-87806"))) {
-						resourceActionsMap = ResourcePermissionUtil.populateResourcePermissionActionIds(portletConfigurationPermissionsDisplayContext.getGroupId(), role, resources, portletConfigurationPermissionsDisplayContext.getActions(), currentIndividualActions, currentGroupActions, currentGroupTemplateActions, currentCompanyActions);
+						resourceActionsMap = portletConfigurationPermissionsDisplayContext.populateResourcePermissionActionIds(portletConfigurationPermissionsDisplayContext.getGroupId(), role, resources, portletConfigurationPermissionsDisplayContext.getActions(), currentIndividualActions, currentGroupActions, currentGroupTemplateActions, currentCompanyActions);
 					}
 					else {
 						ResourcePermissionUtil.populateResourcePermissionActionIds(portletConfigurationPermissionsDisplayContext.getGroupId(), role, resource, portletConfigurationPermissionsDisplayContext.getActions(), currentIndividualActions, currentGroupActions, currentGroupTemplateActions, currentCompanyActions);

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -179,10 +179,6 @@ String resourceName = portletConfigurationPermissionsDisplayContext.getResourceN
 												).put(
 													"indeterminate", indeterminate
 												).put(
-													"indeterminateValue", "indeterminate"
-												).put(
-													"inline", true
-												).put(
 													"name", liferayPortletResponse.getNamespace() + role.getRoleId() + actionSeparator + action
 												).put(
 													"title", dataMessage

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/init.jsp
@@ -66,7 +66,6 @@ page import="com.liferay.portal.kernel.util.PropsUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
-page import="com.liferay.portal.util.ResourcePermissionUtil" %><%@
 page import="com.liferay.portlet.configuration.kernel.util.PortletConfigurationUtil" %><%@
 page import="com.liferay.portlet.configuration.web.internal.display.context.PortletConfigurationPermissionsDisplayContext" %><%@
 page import="com.liferay.portlet.configuration.web.internal.display.context.PortletConfigurationTemplatesDisplayContext" %><%@
@@ -80,7 +79,6 @@ page import="com.liferay.roles.admin.role.type.contributor.provider.RoleTypeCont
 page import="com.liferay.taglib.servlet.PipingServletResponseFactory" %>
 
 <%@ page import="java.util.ArrayList" %><%@
-page import="java.util.HashMap" %><%@
 page import="java.util.LinkedHashSet" %><%@
 page import="java.util.List" %><%@
 page import="java.util.Map" %><%@

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/init.jsp
@@ -60,6 +60,7 @@ page import="com.liferay.portal.kernel.util.LocaleUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.PrefsParamUtil" %><%@
+page import="com.liferay.portal.kernel.util.PropsUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
@@ -77,8 +78,10 @@ page import="com.liferay.roles.admin.role.type.contributor.provider.RoleTypeCont
 page import="com.liferay.taglib.servlet.PipingServletResponseFactory" %>
 
 <%@ page import="java.util.ArrayList" %><%@
+page import="java.util.HashMap" %><%@
 page import="java.util.LinkedHashSet" %><%@
 page import="java.util.List" %><%@
+page import="java.util.Map" %><%@
 page import="java.util.Objects" %><%@
 page import="java.util.Set" %>
 

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/init.jsp
@@ -22,6 +22,7 @@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
@@ -55,6 +56,7 @@ page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.ContentTypes" %><%@
 page import="com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.LocaleUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/PermissionsCheckbox.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/PermissionsCheckbox.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ClayCheckbox} from '@clayui/form';
+import React, {useState} from 'react';
+
+const CHECKBOX_DEFAULT_VALUE = 'on';
+
+const CHECKBOX_STATUS = {
+	checked: 'checked',
+	indeterminate: 'indeterminate',
+	unchecked: 'unchecked',
+};
+
+export default function PermissionsCheckbox({
+	additionalProps: _additionalProps,
+	checked,
+	componentId: _componentId,
+	cssClass,
+	indeterminate,
+	indeterminateValue,
+	locale: _locale,
+	portletId: _portletId,
+	portletNamespace: _portletNamespace,
+	value,
+	...otherProps
+}) {
+	const [checkboxStatus, setCheckboxStatus] = useState(
+		indeterminate
+			? CHECKBOX_STATUS.indeterminate
+			: checked
+			? CHECKBOX_STATUS.checked
+			: CHECKBOX_STATUS.unchecked
+	);
+
+	return (
+		<ClayCheckbox
+			checked={checkboxStatus !== CHECKBOX_STATUS.unchecked}
+			className={cssClass}
+			indeterminate={checkboxStatus === CHECKBOX_STATUS.indeterminate}
+			onChange={() => {
+				setCheckboxStatus((checkboxStatus) =>
+					checkboxStatus === CHECKBOX_STATUS.unchecked
+						? CHECKBOX_STATUS.checked
+						: CHECKBOX_STATUS.unchecked
+				);
+			}}
+			value={
+				checkboxStatus === CHECKBOX_STATUS.indeterminate &&
+				indeterminateValue
+					? indeterminateValue
+					: value
+					? value
+					: CHECKBOX_DEFAULT_VALUE
+			}
+			{...otherProps}
+		/>
+	);
+}

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/PermissionsCheckbox.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/PermissionsCheckbox.js
@@ -29,7 +29,7 @@ export default function PermissionsCheckbox({
 	componentId: _componentId,
 	cssClass,
 	indeterminate,
-	indeterminateValue,
+	indeterminateValue = 'indeterminate',
 	locale: _locale,
 	portletId: _portletId,
 	portletNamespace: _portletNamespace,
@@ -49,6 +49,7 @@ export default function PermissionsCheckbox({
 			checked={checkboxStatus !== CHECKBOX_STATUS.unchecked}
 			className={cssClass}
 			indeterminate={checkboxStatus === CHECKBOX_STATUS.indeterminate}
+			inline
 			onChange={() => {
 				setCheckboxStatus((checkboxStatus) =>
 					checkboxStatus === CHECKBOX_STATUS.unchecked
@@ -57,8 +58,7 @@ export default function PermissionsCheckbox({
 				);
 			}}
 			value={
-				checkboxStatus === CHECKBOX_STATUS.indeterminate &&
-				indeterminateValue
+				checkboxStatus === CHECKBOX_STATUS.indeterminate
 					? indeterminateValue
 					: value
 					? value


### PR DESCRIPTION
Hi @liferay-usm we want you to review this.

With this PR we want to change the behavior of the permission tool, allowing us to change the permission for several documents at the same time. Currently only for documents.

This changes will allow various resourcePrimKey, so as to modify them through the permission modal.
As we have several, we will make a Map with the permission for each of the actions (by actionId), filling it in with the permission for group/company/etc, on top of the individual permission for each of the resources (on `PortletConfigurationPermissionsDisplayContext.populateResourcePermissionActionIds`).
Doing this we can check if each resource has each of the permissions or not. 
It is called indeterminate when a permission is missing a resource but present in another resource (`PortletConfigurationPermissionsDisplayContext.isIndeterminate`).
The delivery of the permission (via the checkbox) activated or deactivated does not change, however the indeterminate state does.
The checkbox states are sent for each permission. This is essential to check if we need to modify each resource permissions.
For this reason we have had to check this new indeterminate state. For each of the actions with the indeterminate state, we check the previous state of the resource to keep it. ( `​​PortletConfigurationPortlet._getIndeterminateStateActionIds` and `​​PortletConfigurationPortlet._getRoleIdsToActionIdsResourcePrimKey`)

For the indeterminate state we used a tri-state checkbox. At the beginning we applied the changes on CheckboxTaglib. 
A PR (https://github.com/liferay-frontend/liferay-portal/pull/2388) was sent to the Frontend Infra Team. They concluded that the behavior was very specific and it was better to create a separate component, so the `PermissionsCheckbox` was created.
In the mentioned PR the behavior of the component is explained in detail.
In a nutshell: the logic of the management toolbar checkbox was applied to this component. When it’s in the indeterminate state a specific value is sent, in this case `indeterminate` instead of the checkbox default value.

A known issue:
We don’t provide any workaround to show tooltips for over disabled elements because we are waiting for it on LPS-104333. If it isn’t implemented, we will provide an alternative solution before removing the feature flag.


To activate the feature the FF is `feature.flag.LPS-87806`