### PR TITLE
LPS-156573 As a user I'd like to have Commerce's MANAGE_AVAILABLE_ACCOUNTS permission available in portal

### DIFF
--- a/modules/apps/account/account-api/bnd.bnd
+++ b/modules/apps/account/account-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Account API
 Bundle-SymbolicName: com.liferay.account.api
-Bundle-Version: 10.1.1
+Bundle-Version: 10.2.0
 Export-Package:\
 	com.liferay.account.configuration,\
 	com.liferay.account.constants,\

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/constants/AccountActionKeys.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/constants/AccountActionKeys.java
@@ -33,6 +33,9 @@ public class AccountActionKeys {
 
 	public static final String MANAGE_ADDRESSES = "MANAGE_ADDRESSES";
 
+	public static final String MANAGE_AVAILABLE_ACCOUNTS =
+		"MANAGE_AVAILABLE_ACCOUNTS";
+
 	public static final String MANAGE_ORGANIZATIONS = "MANAGE_ORGANIZATIONS";
 
 	public static final String MANAGE_SUBORGANIZATIONS_ACCOUNTS =

--- a/modules/apps/account/account-api/src/main/resources/com/liferay/account/constants/packageinfo
+++ b/modules/apps/account/account-api/src/main/resources/com/liferay/account/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/permission/AccountEntrySearchPermissionFilterContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/permission/AccountEntrySearchPermissionFilterContributor.java
@@ -22,18 +22,20 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.spi.model.permission.SearchPermissionFilterContributor;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -78,20 +80,51 @@ public class AccountEntrySearchPermissionFilterContributor
 			"organizationIds");
 
 		try {
+			Set<Organization> organizationsSet = new HashSet<>();
+
+			for (Organization organization :
+					_organizationLocalService.getUserOrganizations(userId)) {
+
+				boolean hasManageAvailableAccountsPermission =
+					_organizationPermission.contains(
+						permissionChecker, organization.getOrganizationId(),
+						AccountActionKeys.MANAGE_AVAILABLE_ACCOUNTS);
+
+				if (hasManageAvailableAccountsPermission ||
+					_organizationPermission.contains(
+						permissionChecker, organization,
+						AccountActionKeys.MANAGE_ACCOUNTS)) {
+
+					organizationsSet.add(organization);
+				}
+
+				if (hasManageAvailableAccountsPermission ||
+					_organizationPermission.contains(
+						permissionChecker, organization,
+						AccountActionKeys.MANAGE_SUBORGANIZATIONS_ACCOUNTS)) {
+
+					List<Organization> suborganizations =
+						_organizationLocalService.getSuborganizations(
+							organization.getCompanyId(),
+							organization.getOrganizationId());
+
+					while (suborganizations.size() > 0) {
+						organizationsSet.addAll(suborganizations);
+
+						suborganizations =
+							_organizationLocalService.getSuborganizations(
+								suborganizations);
+					}
+				}
+			}
+
 			BaseModelSearchResult<Organization> baseModelSearchResult =
 				_organizationLocalService.searchOrganizations(
 					companyId, OrganizationConstants.ANY_PARENT_ORGANIZATION_ID,
 					null,
 					LinkedHashMapBuilder.<String, Object>put(
 						"accountsOrgsTree",
-						() -> {
-							User user = _userLocalService.getUser(userId);
-
-							return ListUtil.filter(
-								user.getOrganizations(true),
-								organization -> _hasManageAccountsPermission(
-									permissionChecker, organization));
-						}
+						ListUtil.fromCollection(organizationsSet)
 					).build(),
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
@@ -112,25 +145,6 @@ public class AccountEntrySearchPermissionFilterContributor
 		}
 	}
 
-	private boolean _hasManageAccountsPermission(
-		PermissionChecker permissionChecker, Organization organization) {
-
-		try {
-			_organizationPermission.check(
-				permissionChecker, organization,
-				AccountActionKeys.MANAGE_ACCOUNTS);
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
-			}
-
-			return false;
-		}
-
-		return true;
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		AccountEntrySearchPermissionFilterContributor.class);
 
@@ -139,8 +153,5 @@ public class AccountEntrySearchPermissionFilterContributor
 
 	@Reference
 	private OrganizationPermission _organizationPermission;
-
-	@Reference
-	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/resource/AccountEntryModelResourcePermission.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/resource/AccountEntryModelResourcePermission.java
@@ -23,13 +23,16 @@ import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.permission.OrganizationPermission;
+import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -102,6 +105,10 @@ public class AccountEntryModelResourcePermission
 			_accountEntryOrganizationRelLocalService.
 				getAccountEntryOrganizationRels(accountEntryId);
 
+		long[] userOrganizationIds =
+			_organizationLocalService.getUserOrganizationIds(
+				permissionChecker.getUserId(), true);
+
 		for (AccountEntryOrganizationRel accountEntryOrganizationRel :
 				accountEntryOrganizationRels) {
 
@@ -109,33 +116,45 @@ public class AccountEntryModelResourcePermission
 				_organizationLocalService.fetchOrganization(
 					accountEntryOrganizationRel.getOrganizationId());
 
-			if (organization == null) {
-				continue;
-			}
+			Organization originalOrganization = organization;
 
-			if (permissionChecker.hasPermission(
-					organization.getGroupId(), AccountEntry.class.getName(),
-					accountEntryId, actionId)) {
+			while (organization != null) {
+				boolean organizationMember = ArrayUtil.contains(
+					userOrganizationIds, organization.getOrganizationId());
 
-				return true;
-			}
-
-			while (!organization.isRoot()) {
-				Organization parentOrganization =
-					organization.getParentOrganization();
-
-				if (_organizationPermission.contains(
-						permissionChecker, parentOrganization,
-						AccountActionKeys.MANAGE_SUBORGANIZATIONS_ACCOUNTS) &&
-					permissionChecker.hasPermission(
-						parentOrganization.getGroupId(),
-						AccountEntry.class.getName(), accountEntryId,
-						actionId)) {
+				if (!Objects.equals(
+						actionId, AccountActionKeys.MANAGE_ORGANIZATIONS) &&
+					organizationMember &&
+					_organizationPermission.contains(
+						permissionChecker, organization.getOrganizationId(),
+						AccountActionKeys.MANAGE_AVAILABLE_ACCOUNTS)) {
 
 					return true;
 				}
 
-				organization = parentOrganization;
+				if (Objects.equals(organization, originalOrganization) &&
+					permissionChecker.hasPermission(
+						organization.getGroupId(), AccountEntry.class.getName(),
+						accountEntryId, actionId)) {
+
+					return true;
+				}
+
+				if (!Objects.equals(organization, originalOrganization) &&
+					_organizationPermission.contains(
+						permissionChecker, organization,
+						AccountActionKeys.MANAGE_SUBORGANIZATIONS_ACCOUNTS) &&
+					((organizationMember &&
+					  Objects.equals(actionId, ActionKeys.VIEW)) ||
+					 permissionChecker.hasPermission(
+						 organization.getGroupId(),
+						 AccountEntry.class.getName(), accountEntryId,
+						 actionId))) {
+
+					return true;
+				}
+
+				organization = organization.getParentOrganization();
 			}
 		}
 

--- a/modules/apps/account/account-service/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/account/account-service/src/main/resources/resource-actions/default.xml
@@ -64,6 +64,7 @@
 		<permissions>
 			<supports>
 				<action-key>MANAGE_ACCOUNTS</action-key>
+				<action-key>MANAGE_AVAILABLE_ACCOUNTS</action-key>
 				<action-key>MANAGE_SUBORGANIZATIONS_ACCOUNTS</action-key>
 			</supports>
 			<guest-unsupported>

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/internal/security/permission/resource/test/AccountEntryModelResourcePermissionTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/internal/security/permission/resource/test/AccountEntryModelResourcePermissionTest.java
@@ -18,16 +18,26 @@ import com.liferay.account.constants.AccountActionKeys;
 import com.liferay.account.constants.AccountConstants;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
+import com.liferay.account.service.test.util.AccountEntryTestUtil;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
@@ -51,6 +61,73 @@ public class AccountEntryModelResourcePermissionTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
+	public void testManageAvailableAccountsPermissions() throws Exception {
+		AccountEntry accountEntry = AccountEntryTestUtil.addAccountEntry(
+			_accountEntryLocalService);
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+		User user = UserTestUtil.addUser();
+
+		RoleTestUtil.addResourcePermission(
+			role, Organization.class.getName(), ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()),
+			AccountActionKeys.MANAGE_AVAILABLE_ACCOUNTS);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		_assertDoesNotContain(user, accountEntry, _ACTION_IDS);
+
+		Organization organization1 = OrganizationTestUtil.addOrganization();
+
+		_userLocalService.addOrganizationUser(
+			organization1.getOrganizationId(), user.getUserId());
+
+		_assertDoesNotContain(user, accountEntry, _ACTION_IDS);
+
+		Organization organization2 = OrganizationTestUtil.addOrganization();
+
+		_accountEntryOrganizationRelLocalService.addAccountEntryOrganizationRel(
+			accountEntry.getAccountEntryId(),
+			organization2.getOrganizationId());
+
+		_assertDoesNotContain(user, accountEntry, _ACTION_IDS);
+
+		Organization organization3 = OrganizationTestUtil.addOrganization();
+
+		_userLocalService.addOrganizationUser(
+			organization3.getOrganizationId(), user.getUserId());
+		_accountEntryOrganizationRelLocalService.addAccountEntryOrganizationRel(
+			accountEntry.getAccountEntryId(),
+			organization3.getOrganizationId());
+
+		_assertContains(user, accountEntry, _ACTION_IDS);
+		_assertDoesNotContain(
+			user, accountEntry, AccountActionKeys.MANAGE_ORGANIZATIONS);
+
+		_accountEntryOrganizationRelLocalService.
+			deleteAccountEntryOrganizationRel(
+				accountEntry.getAccountEntryId(),
+				organization3.getOrganizationId());
+
+		Organization parentOrganization =
+			OrganizationTestUtil.addOrganization();
+
+		_userLocalService.addOrganizationUser(
+			parentOrganization.getOrganizationId(), user.getUserId());
+
+		Organization childOrganization = OrganizationTestUtil.addOrganization(
+			parentOrganization.getOrganizationId(),
+			RandomTestUtil.randomString(), false);
+
+		_accountEntryOrganizationRelLocalService.addAccountEntryOrganizationRel(
+			accountEntry.getAccountEntryId(),
+			childOrganization.getOrganizationId());
+
+		_assertContains(user, accountEntry, _ACTION_IDS);
+		_assertDoesNotContain(
+			user, accountEntry, AccountActionKeys.MANAGE_ORGANIZATIONS);
+	}
+
+	@Test
 	public void testOwnerPermissions() throws Exception {
 		User user = UserTestUtil.addUser();
 
@@ -61,6 +138,13 @@ public class AccountEntryModelResourcePermissionTest {
 			WorkflowConstants.STATUS_APPROVED,
 			ServiceContextTestUtil.getServiceContext());
 
+		_assertContains(user, accountEntry, _ACTION_IDS);
+	}
+
+	private void _assertContains(
+			User user, AccountEntry accountEntry, String... actionIds)
+		throws Exception {
+
 		PermissionChecker originalPermissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
@@ -68,10 +152,13 @@ public class AccountEntryModelResourcePermissionTest {
 			PermissionThreadLocal.setPermissionChecker(
 				PermissionCheckerFactoryUtil.create(user));
 
-			_assertContains(accountEntry, AccountActionKeys.VIEW_USERS);
-			_assertContains(accountEntry, ActionKeys.DELETE);
-			_assertContains(accountEntry, ActionKeys.VIEW);
-			_assertContains(accountEntry, ActionKeys.UPDATE);
+			for (String actionId : actionIds) {
+				Assert.assertTrue(
+					actionId,
+					_accountEntryModelResourcePermission.contains(
+						PermissionThreadLocal.getPermissionChecker(),
+						accountEntry, actionId));
+			}
 		}
 		finally {
 			PermissionThreadLocal.setPermissionChecker(
@@ -79,14 +166,35 @@ public class AccountEntryModelResourcePermissionTest {
 		}
 	}
 
-	private void _assertContains(AccountEntry accountEntry, String actionId)
+	private void _assertDoesNotContain(
+			User user, AccountEntry accountEntry, String... actionIds)
 		throws Exception {
 
-		Assert.assertTrue(
-			_accountEntryModelResourcePermission.contains(
-				PermissionThreadLocal.getPermissionChecker(), accountEntry,
-				actionId));
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(user));
+
+			for (String actionId : actionIds) {
+				Assert.assertFalse(
+					actionId,
+					_accountEntryModelResourcePermission.contains(
+						PermissionThreadLocal.getPermissionChecker(),
+						accountEntry, actionId));
+			}
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
 	}
+
+	private static final String[] _ACTION_IDS = {
+		AccountActionKeys.VIEW_USERS, ActionKeys.DELETE, ActionKeys.VIEW,
+		ActionKeys.UPDATE
+	};
 
 	@Inject
 	private AccountEntryLocalService _accountEntryLocalService;
@@ -94,5 +202,12 @@ public class AccountEntryModelResourcePermissionTest {
 	@Inject(filter = "model.class.name=com.liferay.account.model.AccountEntry")
 	private ModelResourcePermission<AccountEntry>
 		_accountEntryModelResourcePermission;
+
+	@Inject
+	private AccountEntryOrganizationRelLocalService
+		_accountEntryOrganizationRelLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryServiceWhenSearchingAccountEntriesTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryServiceWhenSearchingAccountEntriesTest.java
@@ -23,6 +23,7 @@ import com.liferay.account.service.AccountEntryService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -45,7 +46,6 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
@@ -168,9 +168,9 @@ public class AccountEntryServiceWhenSearchingAccountEntriesTest {
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
 		RoleTestUtil.addResourcePermission(
-			role, PortletKeys.PORTAL, ResourceConstants.SCOPE_COMPANY,
+			role, Organization.class.getName(), ResourceConstants.SCOPE_COMPANY,
 			String.valueOf(TestPropsValues.getCompanyId()),
-			ActionKeys.MANAGE_AVAILABLE_ACCOUNTS);
+			AccountActionKeys.MANAGE_AVAILABLE_ACCOUNTS);
 
 		_userLocalService.addRoleUser(role.getRoleId(), _user);
 
@@ -213,6 +213,30 @@ public class AccountEntryServiceWhenSearchingAccountEntriesTest {
 			role.getRoleId());
 
 		_assertSearch(_organizationAccountEntries.get(_rootOrganization));
+	}
+
+	@Test
+	public void testShouldReturnSuborganizationAccountEntriesWithManageSuborganizationAccountsPermission()
+		throws Exception {
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_ORGANIZATION);
+
+		RoleTestUtil.addResourcePermission(
+			role, Organization.class.getName(),
+			ResourceConstants.SCOPE_GROUP_TEMPLATE,
+			String.valueOf(GroupConstants.DEFAULT_PARENT_GROUP_ID),
+			AccountActionKeys.MANAGE_SUBORGANIZATIONS_ACCOUNTS);
+
+		_userLocalService.addOrganizationUser(
+			_rootOrganization.getOrganizationId(), _user);
+
+		_userGroupRoleLocalService.addUserGroupRole(
+			_user.getUserId(), _rootOrganization.getGroupId(),
+			role.getRoleId());
+
+		_assertSearch(
+			_organizationAccountEntries.get(_organization),
+			_organizationAccountEntries.get(_suborganization));
 	}
 
 	@Test

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryServiceWhenSearchingAccountEntriesTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryServiceWhenSearchingAccountEntriesTest.java
@@ -51,7 +51,6 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -133,7 +132,7 @@ public class AccountEntryServiceWhenSearchingAccountEntriesTest {
 	public void testShouldReturnAllAccountEntriesWithCompanyViewPermission()
 		throws Exception {
 
-		_assertSearch(Collections.emptyList());
+		_assertSearch();
 
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
@@ -150,7 +149,7 @@ public class AccountEntryServiceWhenSearchingAccountEntriesTest {
 	public void testShouldReturnDirectMembershipAccountEntries()
 		throws Exception {
 
-		_assertSearch(Collections.emptyList());
+		_assertSearch();
 
 		AccountEntry accountEntry = _organizationAccountEntries.get(
 			_rootOrganization);
@@ -158,7 +157,7 @@ public class AccountEntryServiceWhenSearchingAccountEntriesTest {
 		_accountEntryUserRelLocalService.addAccountEntryUserRel(
 			accountEntry.getAccountEntryId(), _user.getUserId());
 
-		_assertSearch(Collections.singletonList(accountEntry));
+		_assertSearch(accountEntry);
 	}
 
 	@Test
@@ -170,7 +169,7 @@ public class AccountEntryServiceWhenSearchingAccountEntriesTest {
 				organization.getOrganizationId(), _user);
 		}
 
-		_assertSearch(Collections.emptyList());
+		_assertSearch();
 	}
 
 	@Test
@@ -191,9 +190,7 @@ public class AccountEntryServiceWhenSearchingAccountEntriesTest {
 			_user.getUserId(), _rootOrganization.getGroupId(),
 			role.getRoleId());
 
-		_assertSearch(
-			ListUtil.toList(
-				_organizationAccountEntries.get(_rootOrganization)));
+		_assertSearch(_organizationAccountEntries.get(_rootOrganization));
 	}
 
 	@Test
@@ -216,7 +213,7 @@ public class AccountEntryServiceWhenSearchingAccountEntriesTest {
 		AccountEntry accountEntry = _organizationAccountEntries.get(
 			_organization);
 
-		_assertSearch(ListUtil.toList(accountEntry));
+		_assertSearch(accountEntry);
 
 		RoleTestUtil.addResourcePermission(
 			role, Organization.class.getName(),
@@ -226,7 +223,7 @@ public class AccountEntryServiceWhenSearchingAccountEntriesTest {
 		AccountEntry suborgAccountEntry = _organizationAccountEntries.get(
 			_suborganization);
 
-		_assertSearch(Arrays.asList(accountEntry, suborgAccountEntry));
+		_assertSearch(accountEntry, suborgAccountEntry);
 
 		PermissionChecker permissionChecker =
 			PermissionCheckerFactoryUtil.create(_user);

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryServiceWhenSearchingAccountEntriesTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryServiceWhenSearchingAccountEntriesTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
@@ -161,6 +162,27 @@ public class AccountEntryServiceWhenSearchingAccountEntriesTest {
 	}
 
 	@Test
+	public void testShouldReturnManagedAccountEntriesWithManageAvailableAccountsPermission()
+		throws Exception {
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		RoleTestUtil.addResourcePermission(
+			role, PortletKeys.PORTAL, ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(TestPropsValues.getCompanyId()),
+			ActionKeys.MANAGE_AVAILABLE_ACCOUNTS);
+
+		_userLocalService.addRoleUser(role.getRoleId(), _user);
+
+		_userLocalService.addOrganizationUser(
+			_organization.getOrganizationId(), _user);
+
+		_assertSearch(
+			_organizationAccountEntries.get(_organization),
+			_organizationAccountEntries.get(_suborganization));
+	}
+
+	@Test
 	public void testShouldReturnNoAccountEntriesWithoutManageAccountsPermission()
 		throws Exception {
 
@@ -270,6 +292,12 @@ public class AccountEntryServiceWhenSearchingAccountEntriesTest {
 		return _roleLocalService.addRole(
 			TestPropsValues.getUserId(), null, 0, RandomTestUtil.randomString(),
 			null, null, RoleConstants.TYPE_ORGANIZATION, null, null);
+	}
+
+	private void _assertSearch(AccountEntry... expectedAccountEntries)
+		throws Exception {
+
+		_assertSearch(Arrays.asList(expectedAccountEntries));
 	}
 
 	private void _assertSearch(List<AccountEntry> expectedAccountEntries)


### PR DESCRIPTION
This is an update for [LPS-156573](https://issues.liferay.com/browse/LPS-156573).

@pei-jung a notable addition with this pull request: The `MANAGE_SUBORGANIZATIONS_ACCOUNTS` action now grants `VIEW` privileges for accounts associated with the suborganizations by default. For all other actions acting on sub-org accounts, the relevant permissions are still required.

/cc @pei-jung @ChrisKian @patriciajeanperez @epark18 @david-truong @gislayne-vitorino @RafaelCRC