### PR TITLE
LPS-161233 Add default getSearchActionURL to BaseManagementToolbarDisplayContext

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/BaseManagementToolbarDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/BaseManagementToolbarDisplayContext.java
@@ -121,6 +121,13 @@ public class BaseManagementToolbarDisplayContext
 	}
 
 	@Override
+	public String getSearchActionURL() {
+		PortletURL searchActionURL = getPortletURL();
+
+		return searchActionURL.toString();
+	}
+
+	@Override
 	public String getSortingOrder() {
 		return getOrderByType();
 	}


### PR DESCRIPTION
This is an update for [LPS-161233](https://issues.liferay.com/browse/LPS-161233).