### PR TITLE
LPS-163292 Implement API Search and delete test related roles

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRole.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRole.macro
@@ -105,4 +105,12 @@ definition {
 		JSONRoleAPI._deleteRoleById(roleId = "${roleId}");
 	}
 
+	macro deleteTestRoles {
+		var rolesIds = JSONRoleAPI._searchRolesIds(roleName = "Test");
+
+		for (var roleId : list "${rolesIds}") {
+			JSONRoleAPI._deleteRoleById(roleId = "${roleId}");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRoleAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/roles/JSONRoleAPI.macro
@@ -118,4 +118,27 @@ definition {
 		return "${roleId}";
 	}
 
+	macro _searchRolesIds {
+		Variables.assertDefined(parameterList = "${roleName}");
+
+		var companyId = JSONCompany.getCompanyId();
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/api/jsonws/role/search \
+				-u test@liferay.com:test \
+				-d companyId=${companyId} \
+				-d keywords=${roleName} \
+				-d types= \
+				-d -params= \
+				-d "start=-1" \
+				-d "end=-1"
+				-d -orderByComparator=
+		''';
+
+		var rolesIds = JSONCurlUtil.post("${curl}", "$..['roleId']");
+
+		return "${rolesIds}";
+	}
+
 }


### PR DESCRIPTION
**Ticket**:
[LPS-163292](https://issues.liferay.com/browse/LPS-163292)

**Motivation**:
Several tests across many teams use JSONRole macro at its implementation. But as there are more Roles being created, many times they are not deleted. Besides that, not all tests at the same testcase use JSONRole, so they they need to be deleted at the test itself (not at the tearDown).

**Proposed Solution**:

1. Implement [/role/search](http://localhost:8080/api/jsonws?contextName=&signature=%2Frole%2Fsearch-7-long-java.lang.String-%5BLjava.lang.Integer%3B-java.util.LinkedHashMap-int-int-com.liferay.portal.kernel.util.OrderByComparator) API, to return the ID(s) of the role(s).
2. Use this API call to return all _roleIds_ that contains 'TEST' in its title. 

The idea is to, at each _test_, when using JSONRole.addRegularRole (or similar), add a 'test' to its _roleTitle_.

```
JSONRole.addRegularRole(
	roleKey = "Test Role Edit Pages",
	roleTitle = "Test Role Edit Pages");
```
Therefore, only by calling the macro (as bellow), it'll delete the role. So, it can be used at _tearDown_, where the usage follows best practices. 

```
JSONRole.deleteTestRoles();
```