### PR TITLE
LPS-162532 Enable unique permission checking for editing account domains

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/EditAccountEntryMVCActionCommand.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/EditAccountEntryMVCActionCommand.java
@@ -142,7 +142,7 @@ public class EditAccountEntryMVCActionCommand
 
 		String[] domains = accountEntry.getDomainsArray();
 
-		if (_isAllowUpdateDomains(actionRequest, accountEntry.getType())) {
+		if (_isAllowUpdateDomains(accountEntry.getType())) {
 			domains = ParamUtil.getStringValues(actionRequest, "domains");
 		}
 
@@ -198,7 +198,7 @@ public class EditAccountEntryMVCActionCommand
 			actionRequest, "type",
 			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS);
 
-		if (_isAllowUpdateDomains(actionRequest, type)) {
+		if (_isAllowUpdateDomains(type)) {
 			domains = ParamUtil.getStringValues(actionRequest, "domains");
 		}
 
@@ -237,14 +237,9 @@ public class EditAccountEntryMVCActionCommand
 		return WorkflowConstants.STATUS_INACTIVE;
 	}
 
-	private boolean _isAllowUpdateDomains(
-		ActionRequest actionRequest, String type) {
-
+	private boolean _isAllowUpdateDomains(String type) {
 		if (Objects.equals(
-				AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS, type) &&
-			Objects.equals(
-				AccountPortletKeys.ACCOUNT_ENTRIES_ADMIN,
-				_portal.getPortletId(actionRequest))) {
+				AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS, type)) {
 
 			return true;
 		}

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
@@ -21,7 +21,7 @@ AccountEntryDisplay accountEntryDisplay = (AccountEntryDisplay)request.getAttrib
 
 List<String> domains = accountEntryDisplay.getDomains();
 
-boolean allowUpdateDomains = portletName.equals(AccountPortletKeys.ACCOUNT_ENTRIES_ADMIN);
+boolean allowUpdateDomains = AccountEntryPermission.contains(permissionChecker, accountEntryDisplay.getAccountEntryId(), AccountActionKeys.MANAGE_DOMAINS);
 %>
 
 <liferay-ui:error exception="<%= AccountEntryDomainsException.class %>" message="please-enter-a-valid-mail-domain" />

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/constants/AccountActionKeys.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/constants/AccountActionKeys.java
@@ -36,6 +36,8 @@ public class AccountActionKeys {
 	public static final String MANAGE_AVAILABLE_ACCOUNTS =
 		"MANAGE_AVAILABLE_ACCOUNTS";
 
+	public static final String MANAGE_DOMAINS = "MANAGE_DOMAINS";
+
 	public static final String MANAGE_ORGANIZATIONS = "MANAGE_ORGANIZATIONS";
 
 	public static final String MANAGE_SUBORGANIZATIONS_ACCOUNTS =

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalService.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalService.java
@@ -444,6 +444,10 @@ public interface AccountEntryLocalService
 		throws PortalException;
 
 	@Indexable(type = IndexableType.REINDEX)
+	public AccountEntry updateDomains(long accountEntryId, String[] domains)
+		throws PortalException;
+
+	@Indexable(type = IndexableType.REINDEX)
 	public AccountEntry updateExternalReferenceCode(
 			AccountEntry accountEntry, String externalReferenceCode)
 		throws PortalException;

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalServiceUtil.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalServiceUtil.java
@@ -556,6 +556,13 @@ public class AccountEntryLocalServiceUtil {
 			accountEntryId, addressId);
 	}
 
+	public static AccountEntry updateDomains(
+			long accountEntryId, String[] domains)
+		throws PortalException {
+
+		return getService().updateDomains(accountEntryId, domains);
+	}
+
 	public static AccountEntry updateExternalReferenceCode(
 			AccountEntry accountEntry, String externalReferenceCode)
 		throws PortalException {

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalServiceWrapper.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryLocalServiceWrapper.java
@@ -646,6 +646,14 @@ public class AccountEntryLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.account.model.AccountEntry updateDomains(
+			long accountEntryId, String[] domains)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _accountEntryLocalService.updateDomains(accountEntryId, domains);
+	}
+
+	@Override
 	public com.liferay.account.model.AccountEntry updateExternalReferenceCode(
 			com.liferay.account.model.AccountEntry accountEntry,
 			String externalReferenceCode)

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryService.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryService.java
@@ -124,6 +124,9 @@ public interface AccountEntryService extends BaseService {
 			int status, ServiceContext serviceContext)
 		throws PortalException;
 
+	public AccountEntry updateDomains(long accountEntryId, String[] domains)
+		throws PortalException;
+
 	public AccountEntry updateExternalReferenceCode(
 			long accountEntryId, String externalReferenceCode)
 		throws PortalException;

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryServiceUtil.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryServiceUtil.java
@@ -161,6 +161,13 @@ public class AccountEntryServiceUtil {
 			serviceContext);
 	}
 
+	public static AccountEntry updateDomains(
+			long accountEntryId, String[] domains)
+		throws PortalException {
+
+		return getService().updateDomains(accountEntryId, domains);
+	}
+
 	public static AccountEntry updateExternalReferenceCode(
 			long accountEntryId, String externalReferenceCode)
 		throws PortalException {

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryServiceWrapper.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/service/AccountEntryServiceWrapper.java
@@ -179,6 +179,14 @@ public class AccountEntryServiceWrapper
 	}
 
 	@Override
+	public com.liferay.account.model.AccountEntry updateDomains(
+			long accountEntryId, String[] domains)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _accountEntryService.updateDomains(accountEntryId, domains);
+	}
+
+	@Override
 	public com.liferay.account.model.AccountEntry updateExternalReferenceCode(
 			long accountEntryId, String externalReferenceCode)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/account/account-api/src/main/resources/com/liferay/account/service/packageinfo
+++ b/modules/apps/account/account-api/src/main/resources/com/liferay/account/service/packageinfo
@@ -1,1 +1,1 @@
-version 7.3.0
+version 7.4.0

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/http/AccountEntryServiceHttp.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/http/AccountEntryServiceHttp.java
@@ -622,6 +622,46 @@ public class AccountEntryServiceHttp {
 		}
 	}
 
+	public static com.liferay.account.model.AccountEntry updateDomains(
+			HttpPrincipal httpPrincipal, long accountEntryId, String[] domains)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				AccountEntryServiceUtil.class, "updateDomains",
+				_updateDomainsParameterTypes14);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, accountEntryId, domains);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.account.model.AccountEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.account.model.AccountEntry
 			updateExternalReferenceCode(
 				HttpPrincipal httpPrincipal, long accountEntryId,
@@ -631,7 +671,7 @@ public class AccountEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AccountEntryServiceUtil.class, "updateExternalReferenceCode",
-				_updateExternalReferenceCodeParameterTypes14);
+				_updateExternalReferenceCodeParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, accountEntryId, externalReferenceCode);
@@ -714,8 +754,10 @@ public class AccountEntryServiceHttp {
 			String[].class, String.class, byte[].class, String.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
+	private static final Class<?>[] _updateDomainsParameterTypes14 =
+		new Class[] {long.class, String[].class};
 	private static final Class<?>[]
-		_updateExternalReferenceCodeParameterTypes14 = new Class[] {
+		_updateExternalReferenceCodeParameterTypes15 = new Class[] {
 			long.class, String.class
 		};
 

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
@@ -175,10 +175,6 @@ public class AccountEntryLocalServiceImpl
 			_accountEntryEmailAddressValidatorFactory.create(
 				user.getCompanyId());
 
-		domains = _validateDomains(accountEntryEmailAddressValidator, domains);
-
-		accountEntry.setDomains(StringUtil.merge(domains, StringPool.COMMA));
-
 		_validateEmailAddress(accountEntryEmailAddressValidator, emailAddress);
 
 		accountEntry.setEmailAddress(emailAddress);
@@ -197,6 +193,10 @@ public class AccountEntryLocalServiceImpl
 		accountEntry.setStatus(status);
 
 		accountEntry = accountEntryPersistence.update(accountEntry);
+
+		if (domains != null) {
+			accountEntry = updateDomains(accountEntryId, domains);
+		}
 
 		// Group
 
@@ -597,10 +597,6 @@ public class AccountEntryLocalServiceImpl
 			_accountEntryEmailAddressValidatorFactory.create(
 				accountEntry.getCompanyId());
 
-		domains = _validateDomains(accountEntryEmailAddressValidator, domains);
-
-		accountEntry.setDomains(StringUtil.merge(domains, StringPool.COMMA));
-
 		_validateEmailAddress(accountEntryEmailAddressValidator, emailAddress);
 
 		accountEntry.setEmailAddress(emailAddress);
@@ -625,7 +621,13 @@ public class AccountEntryLocalServiceImpl
 			accountEntry.setExpandoBridgeAttributes(serviceContext);
 		}
 
-		return accountEntryPersistence.update(accountEntry);
+		accountEntry = accountEntryPersistence.update(accountEntry);
+
+		if (domains != null) {
+			accountEntry = updateDomains(accountEntryId, domains);
+		}
+
+		return accountEntry;
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
@@ -656,6 +656,24 @@ public class AccountEntryLocalServiceImpl
 
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
+	public AccountEntry updateDomains(long accountEntryId, String[] domains)
+		throws PortalException {
+
+		AccountEntry accountEntry = getAccountEntry(accountEntryId);
+
+		AccountEntryEmailAddressValidator accountEntryEmailAddressValidator =
+			_accountEntryEmailAddressValidatorFactory.create(
+				accountEntry.getCompanyId());
+
+		domains = _validateDomains(accountEntryEmailAddressValidator, domains);
+
+		accountEntry.setDomains(StringUtil.merge(domains, StringPool.COMMA));
+
+		return updateAccountEntry(accountEntry);
+	}
+
+	@Indexable(type = IndexableType.REINDEX)
+	@Override
 	public AccountEntry updateExternalReferenceCode(
 			AccountEntry accountEntry, String externalReferenceCode)
 		throws PortalException {

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
@@ -79,8 +79,9 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 			getPermissionChecker(), AccountActionKeys.ADD_ACCOUNT_ENTRY);
 
 		return accountEntryLocalService.addAccountEntry(
-			userId, parentAccountEntryId, name, description, domains, email,
-			logoBytes, taxIdNumber, type, status, serviceContext);
+			userId, parentAccountEntryId, name, description,
+			_getManageableDomains(0L, domains), email, logoBytes, taxIdNumber,
+			type, status, serviceContext);
 	}
 
 	@Override
@@ -98,6 +99,8 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 			accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
 				permissionChecker.getCompanyId(), externalReferenceCode);
 
+		long accountEntryId = 0L;
+
 		if (accountEntry == null) {
 			_portalPermission.check(
 				permissionChecker, AccountActionKeys.ADD_ACCOUNT_ENTRY);
@@ -106,12 +109,14 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 			_accountEntryModelResourcePermission.check(
 				permissionChecker, permissionChecker.getCompanyId(),
 				ActionKeys.UPDATE);
+
+			accountEntryId = accountEntry.getAccountEntryId();
 		}
 
 		return accountEntryLocalService.addOrUpdateAccountEntry(
 			externalReferenceCode, userId, parentAccountEntryId, name,
-			description, domains, emailAddress, logoBytes, taxIdNumber, type,
-			status, serviceContext);
+			description, _getManageableDomains(accountEntryId, domains),
+			emailAddress, logoBytes, taxIdNumber, type, status, serviceContext);
 	}
 
 	@Override
@@ -220,6 +225,17 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 		_accountEntryModelResourcePermission.check(
 			getPermissionChecker(), accountEntry, ActionKeys.UPDATE);
 
+		if (!_accountEntryModelResourcePermission.contains(
+				getPermissionChecker(), accountEntry.getAccountEntryId(),
+				AccountActionKeys.MANAGE_DOMAINS)) {
+
+			AccountEntry originalAccountEntry =
+				accountEntryLocalService.getAccountEntry(
+					accountEntry.getAccountEntryId());
+
+			accountEntry.setDomains(originalAccountEntry.getDomains());
+		}
+
 		return accountEntryLocalService.updateAccountEntry(accountEntry);
 	}
 
@@ -236,8 +252,8 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 
 		return accountEntryLocalService.updateAccountEntry(
 			accountEntryId, parentAccountEntryId, name, description, deleteLogo,
-			domains, emailAddress, logoBytes, taxIdNumber, status,
-			serviceContext);
+			_getManageableDomains(accountEntryId, domains), emailAddress,
+			logoBytes, taxIdNumber, status, serviceContext);
 	}
 
 	@Override
@@ -261,6 +277,20 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 
 		return accountEntryLocalService.updateExternalReferenceCode(
 			accountEntryId, externalReferenceCode);
+	}
+
+	private String[] _getManageableDomains(
+			long accountEntryId, String[] domains)
+		throws PortalException {
+
+		if (_accountEntryModelResourcePermission.contains(
+				getPermissionChecker(), accountEntryId,
+				AccountActionKeys.MANAGE_DOMAINS)) {
+
+			return domains;
+		}
+
+		return null;
 	}
 
 	@Reference(

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
@@ -241,6 +241,17 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 	}
 
 	@Override
+	public AccountEntry updateDomains(long accountEntryId, String[] domains)
+		throws PortalException {
+
+		_accountEntryModelResourcePermission.check(
+			getPermissionChecker(), accountEntryId,
+			AccountActionKeys.MANAGE_DOMAINS);
+
+		return accountEntryLocalService.updateDomains(accountEntryId, domains);
+	}
+
+	@Override
 	public AccountEntry updateExternalReferenceCode(
 			long accountEntryId, String externalReferenceCode)
 		throws PortalException {

--- a/modules/apps/account/account-service/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/account/account-service/src/main/resources/resource-actions/default.xml
@@ -13,6 +13,7 @@
 				<action-key>ADD_ACCOUNT_ROLE</action-key>
 				<action-key>DELETE</action-key>
 				<action-key>MANAGE_ADDRESSES</action-key>
+				<action-key>MANAGE_DOMAINS</action-key>
 				<action-key>MANAGE_ORGANIZATIONS</action-key>
 				<action-key>MANAGE_USERS</action-key>
 				<action-key>UPDATE</action-key>

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryLocalServiceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryLocalServiceTest.java
@@ -1036,6 +1036,38 @@ public class AccountEntryLocalServiceTest {
 		_assertPaginationSort(expectedAccountEntries, keywords, true);
 	}
 
+	@Test
+	public void testUpdateDomains() throws Exception {
+		AccountEntry accountEntry = AccountEntryTestUtil.addAccountEntry(
+			_accountEntryLocalService);
+
+		Assert.assertArrayEquals(new String[0], accountEntry.getDomainsArray());
+
+		String[] expectedDomains = {"foo.com", "bar.com"};
+
+		accountEntry = _accountEntryLocalService.updateDomains(
+			accountEntry.getAccountEntryId(), expectedDomains);
+
+		Assert.assertArrayEquals(
+			ArrayUtil.sortedUnique(expectedDomains),
+			ArrayUtil.sortedUnique(accountEntry.getDomainsArray()));
+
+		BaseModelSearchResult<AccountEntry> baseModelSearchResult =
+			_accountEntryLocalService.searchAccountEntries(
+				accountEntry.getCompanyId(), null,
+				LinkedHashMapBuilder.<String, Object>put(
+					"domains", expectedDomains
+				).build(),
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null, false);
+
+		Assert.assertEquals(1, baseModelSearchResult.getLength());
+
+		List<AccountEntry> accountEntries =
+			baseModelSearchResult.getBaseModels();
+
+		Assert.assertEquals(accountEntry, accountEntries.get(0));
+	}
+
 	@Rule
 	public SearchTestRule searchTestRule = new SearchTestRule();
 

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryLocalServiceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryLocalServiceTest.java
@@ -327,9 +327,14 @@ public class AccountEntryLocalServiceTest {
 		AccountEntry accountEntry = AccountEntryTestUtil.addAccountEntry(
 			_accountEntryLocalService, domains);
 
-		Assert.assertEquals(
-			StringUtil.merge(ArrayUtil.distinct(expectedDomains), ","),
-			accountEntry.getDomains());
+		Assert.assertArrayEquals(
+			ArrayUtil.sortedUnique(expectedDomains),
+			ArrayUtil.sortedUnique(accountEntry.getDomainsArray()));
+
+		accountEntry = AccountEntryTestUtil.addAccountEntry(
+			_accountEntryLocalService, null);
+
+		Assert.assertArrayEquals(new String[0], accountEntry.getDomainsArray());
 	}
 
 	@Test
@@ -1034,6 +1039,36 @@ public class AccountEntryLocalServiceTest {
 
 		_assertPaginationSort(expectedAccountEntries, keywords, false);
 		_assertPaginationSort(expectedAccountEntries, keywords, true);
+	}
+
+	@Test
+	public void testUpdateAccountEntry() throws Exception {
+		AccountEntry accountEntry = AccountEntryTestUtil.addAccountEntry(
+			_accountEntryLocalService);
+
+		String[] expectedDomains = {"update1.com", "update2.com"};
+
+		accountEntry = _accountEntryLocalService.updateAccountEntry(
+			accountEntry.getAccountEntryId(),
+			accountEntry.getParentAccountEntryId(), accountEntry.getName(),
+			accountEntry.getDescription(), false, expectedDomains,
+			accountEntry.getEmailAddress(), null, accountEntry.getTaxIdNumber(),
+			accountEntry.getStatus(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertArrayEquals(
+			expectedDomains, accountEntry.getDomainsArray());
+
+		accountEntry = _accountEntryLocalService.updateAccountEntry(
+			accountEntry.getAccountEntryId(),
+			accountEntry.getParentAccountEntryId(), accountEntry.getName(),
+			accountEntry.getDescription(), false, null,
+			accountEntry.getEmailAddress(), null, accountEntry.getTaxIdNumber(),
+			accountEntry.getStatus(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertArrayEquals(
+			expectedDomains, accountEntry.getDomainsArray());
 	}
 
 	@Test

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -408,6 +408,7 @@ action.MANAGE_COMMERCE_WISH_LISTS=Manage Wish Lists
 action.MANAGE_COUNTRIES=Manage Countries
 action.MANAGE_COUPONS=Manage Coupons
 action.MANAGE_DEVICES=Manage Devices
+action.MANAGE_DOMAINS=Manage Domains
 action.MANAGE_FRAGMENT_ENTRIES=Manage Fragment Entries
 action.MANAGE_INVENTORY=Manage Inventory
 action.MANAGE_LANGUAGE_OVERRIDES=Manage Language Overrides


### PR DESCRIPTION
This is an update for [LPS-162532](https://issues.liferay.com/browse/LPS-162532).

@patriciajeanperez we need to update functional tests because of this one. 

The ability to edit domains via the UI is now controlled by the MANAGE_DOMAINS permission on the AccountEntry.

It is _no longer_ dependent on whether we are in the admin portlet or the widget.