### PR TITLE
LPS-165421

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -998,10 +998,12 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		attributes.put("description", description);
 		attributes.put("name", name);
 
-		long[] userIds = (long[])params.get("userIds");
+		if (params != null) {
+			long[] userIds = (long[])params.get("userIds");
 
-		if (ArrayUtil.isNotEmpty(userIds)) {
-			attributes.put("userIds", userIds);
+			if (ArrayUtil.isNotEmpty(userIds)) {
+				attributes.put("userIds", userIds);
+			}
 		}
 
 		searchContext.setAttributes(attributes);

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -1004,20 +1004,18 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 			if (ArrayUtil.isNotEmpty(userIds)) {
 				attributes.put("userIds", userIds);
 			}
-		}
 
-		searchContext.setAttributes(attributes);
-
-		searchContext.setCompanyId(companyId);
-		searchContext.setEnd(end);
-
-		if (params != null) {
 			String keywords = (String)params.remove("keywords");
 
 			if (Validator.isNotNull(keywords)) {
 				searchContext.setKeywords(keywords);
 			}
 		}
+
+		searchContext.setAttributes(attributes);
+
+		searchContext.setCompanyId(companyId);
+		searchContext.setEnd(end);
 
 		if (sort != null) {
 			searchContext.setSorts(sort);


### PR DESCRIPTION
If the team feels that alphabetizing the _set*_ calls for _searchContext_ is better then the second commit can be dropped, otherwise this only checks for a non-null _params_ once.