### PR TITLE
[TS] LPS-164469 Guest users get a 200 OK when calling /manage URL

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -217,9 +217,10 @@ public class FriendlyURLServlet extends HttpServlet {
 			Layout layout = layoutFriendlyURLSeparatorComposite.getLayout();
 
 			if (layout != null) {
+				User user = _getUser(httpServletRequest);
+
 				PermissionChecker permissionChecker =
-					PermissionCheckerFactoryUtil.create(
-						_getUser(httpServletRequest));
+					PermissionCheckerFactoryUtil.create(user);
 
 				if (!LayoutPermissionUtil.contains(
 						permissionChecker, layout, ActionKeys.VIEW)) {
@@ -234,6 +235,14 @@ public class FriendlyURLServlet extends HttpServlet {
 					}
 
 					throw new LayoutPermissionException();
+				}
+
+				if (user.isDefaultUser() && layout.isSystem() &&
+					Objects.equals(
+						layout.getFriendlyURL(),
+						PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL)) {
+
+					throw new NoSuchLayoutException();
 				}
 
 				if ((redirectProviderRedirect != null) &&


### PR DESCRIPTION
Related Jira issues:
- [PTR-3377](https://issues.liferay.com/browse/PTR-3377) 
- [LPS-164469](https://issues.liferay.com/browse/LPS-164469)

---

Hi team @liferay-usm!

As discussed in PTR-3377, we should prevent guest users from getting a 200 OK response when requesting `/manage` page (or whatever is set in `control.panel.layout.friendly.url`). 

In order to have the lest impact, I have added an extra check in FriendlyURLServlet and return a NoSuchLayoutException if the user is not logged in.

Could you review these changes?

Thanks!
