### PR TITLE
LPS-166303 Escape Apostrophe/Quote in localization lookups through ResourceBundleUtil

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/ResourceBundleUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ResourceBundleUtil.java
@@ -16,6 +16,8 @@ package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.concurrent.ConcurrentReferenceKeyHashMap;
 import com.liferay.petra.memory.FinalizeManager;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageBuilderUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.language.UTF8Control;
@@ -165,12 +167,17 @@ public class ResourceBundleUtil {
 
 		if (ArrayUtil.isNotEmpty(arguments)) {
 			MessageFormat messageFormat = new MessageFormat(
-				value, resourceBundle.getLocale());
+				_escapePattern(value), resourceBundle.getLocale());
 
 			value = messageFormat.format(arguments);
 		}
 
 		return value;
+	}
+
+	private static String _escapePattern(String pattern) {
+		return StringUtil.replace(
+			pattern, CharPool.APOSTROPHE, StringPool.DOUBLE_APOSTROPHE);
 	}
 
 	private static ResourceBundle _getBundle(


### PR DESCRIPTION
This is an update for [LPS-166303](https://issues.liferay.com/browse/LPS-166303).<br/><br/>/cc @olafk @pei-jung