### PR TITLE
LPS-166303 Escape Apostrophe/Quote in localization lookups through ResourceBundleUtil

### DIFF
--- a/modules/apps/portal-language/portal-language-test/source-formatter-suppressions.xml
+++ b/modules/apps/portal-language/portal-language-test/source-formatter-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<checkstyle>
+		<suppress checks="ContractionsCheck" files="src/testIntegration/java/com/liferay/portal/language/test/ResourceBundleUtilTest\.java" />
+	</checkstyle>
+</suppressions>

--- a/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/ResourceBundleUtilTest.java
+++ b/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/ResourceBundleUtilTest.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -73,6 +74,27 @@ public class ResourceBundleUtilTest {
 						_UNSUPPORTED_LOCALE),
 					portalKeys));
 		}
+
+		String key = "x-its-x";
+
+		Assert.assertEquals(
+			"foo it's bar",
+			ResourceBundleUtil.getString(
+				new ResourceBundle() {
+
+					@Override
+					public Enumeration<String> getKeys() {
+						return Collections.enumeration(
+							Collections.singletonList(key));
+					}
+
+					@Override
+					protected Object handleGetObject(String key) {
+						return "{0} it's {1}";
+					}
+
+				},
+				key, "foo", "bar"));
 	}
 
 	private void _testGetString(

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ResourceBundleUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ResourceBundleUtil.java
@@ -16,6 +16,8 @@ package com.liferay.portal.kernel.util;
 
 import com.liferay.petra.concurrent.ConcurrentReferenceKeyHashMap;
 import com.liferay.petra.memory.FinalizeManager;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageBuilderUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.language.UTF8Control;
@@ -165,12 +167,17 @@ public class ResourceBundleUtil {
 
 		if (ArrayUtil.isNotEmpty(arguments)) {
 			MessageFormat messageFormat = new MessageFormat(
-				value, resourceBundle.getLocale());
+				_escapePattern(value), resourceBundle.getLocale());
 
 			value = messageFormat.format(arguments);
 		}
 
 		return value;
+	}
+
+	private static String _escapePattern(String pattern) {
+		return StringUtil.replace(
+			pattern, CharPool.APOSTROPHE, StringPool.DOUBLE_APOSTROPHE);
 	}
 
 	private static ResourceBundle _getBundle(


### PR DESCRIPTION
This is an update for [LPS-166303](https://issues.liferay.com/browse/LPS-166303).<br/><br/>/cc @olafk @pei-jung