### PR TITLE
LPS-163793

### DIFF
--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
@@ -753,33 +753,53 @@ public class EditServerMVCActionCommand
 		portletPreferences.setValue(
 			PropsKeys.MAIL_SESSION_MAIL_ADVANCED_PROPERTIES,
 			advancedProperties);
-		portletPreferences.setValue(
-			PropsKeys.MAIL_SESSION_MAIL_POP3_HOST, pop3Host);
+
+		if (!pop3Host.equals(StringPool.BLANK)) {
+			portletPreferences.setValue(
+				PropsKeys.MAIL_SESSION_MAIL_POP3_HOST, pop3Host);
+		}
 
 		if (!pop3Password.equals(Portal.TEMP_OBFUSCATION_VALUE)) {
 			portletPreferences.setValue(
 				PropsKeys.MAIL_SESSION_MAIL_POP3_PASSWORD, pop3Password);
 		}
 
-		portletPreferences.setValue(
-			PropsKeys.MAIL_SESSION_MAIL_POP3_PORT, String.valueOf(pop3Port));
-		portletPreferences.setValue(
-			PropsKeys.MAIL_SESSION_MAIL_POP3_USER, pop3User);
-		portletPreferences.setValue(
-			PropsKeys.MAIL_SESSION_MAIL_SMTP_HOST, smtpHost);
+		if (pop3Port > 0) {
+			portletPreferences.setValue(
+				PropsKeys.MAIL_SESSION_MAIL_POP3_PORT,
+				String.valueOf(pop3Port));
+		}
+
+		if (!pop3User.equals(StringPool.BLANK)) {
+			portletPreferences.setValue(
+				PropsKeys.MAIL_SESSION_MAIL_POP3_USER, pop3User);
+		}
+
+		if (!smtpHost.equals(StringPool.BLANK)) {
+			portletPreferences.setValue(
+				PropsKeys.MAIL_SESSION_MAIL_SMTP_HOST, smtpHost);
+		}
 
 		if (!smtpPassword.equals(Portal.TEMP_OBFUSCATION_VALUE)) {
 			portletPreferences.setValue(
 				PropsKeys.MAIL_SESSION_MAIL_SMTP_PASSWORD, smtpPassword);
 		}
 
-		portletPreferences.setValue(
-			PropsKeys.MAIL_SESSION_MAIL_SMTP_PORT, String.valueOf(smtpPort));
+		if (smtpPort > 0) {
+			portletPreferences.setValue(
+				PropsKeys.MAIL_SESSION_MAIL_SMTP_PORT,
+				String.valueOf(smtpPort));
+		}
+
 		portletPreferences.setValue(
 			PropsKeys.MAIL_SESSION_MAIL_SMTP_STARTTLS_ENABLE,
 			String.valueOf(smtpStartTLSEnable));
-		portletPreferences.setValue(
-			PropsKeys.MAIL_SESSION_MAIL_SMTP_USER, smtpUser);
+
+		if (!smtpUser.equals(StringPool.BLANK)) {
+			portletPreferences.setValue(
+				PropsKeys.MAIL_SESSION_MAIL_SMTP_USER, smtpUser);
+		}
+
 		portletPreferences.setValue(
 			PropsKeys.MAIL_SESSION_MAIL_STORE_PROTOCOL, storeProtocol);
 		portletPreferences.setValue(

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -85,7 +85,7 @@ page import="java.util.Map" %><%@
 page import="java.util.Objects" %><%@
 page import="java.util.Properties" %><%@
 page import="java.util.TreeMap" %><%@
-page import="java.util.function.Function" %>
+page import="java.util.function.BiFunction" %>
 
 <%@ page import="javax.portlet.PortletPreferences" %><%@
 page import="javax.portlet.PortletURL" %>

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/mail_fields.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/mail_fields.jsp
@@ -23,22 +23,22 @@ PortletPreferences companyPortletPreferences = PrefsPropsUtil.getPreferences(com
 
 PortletPreferences systemPortletPreferences = PrefsPropsUtil.getPreferences(0L);
 
-Function<String, String> function = (String key) -> companyPortletPreferences.getValue(key, systemPortletPreferences.getValue(key, PropsUtil.get(key)));
+BiFunction<String, Boolean, String> biFunction = (key, usePropsUtil) -> companyPortletPreferences.getValue(key, systemPortletPreferences.getValue(key, usePropsUtil ? PropsUtil.get(key) : StringPool.BLANK));
 %>
 
 <aui:fieldset>
 	<aui:input name="preferencesCompanyId" type="hidden" value="<%= companyId %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="incoming-pop-server" name="pop3Host" type="text" value="<%= function.apply(PropsKeys.MAIL_SESSION_MAIL_POP3_HOST) %>" />
+	<aui:input cssClass="lfr-input-text-container" label="incoming-pop-server" name="pop3Host" type="text" value="<%= biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_POP3_HOST, permissionChecker.isOmniadmin()) %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="incoming-port" name="pop3Port" type="text" value="<%= function.apply(PropsKeys.MAIL_SESSION_MAIL_POP3_PORT) %>" />
+	<aui:input cssClass="lfr-input-text-container" label="incoming-port" name="pop3Port" type="text" value="<%= biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_POP3_PORT, permissionChecker.isOmniadmin()) %>" />
 
-	<aui:input label="use-a-secure-network-connection" name="pop3Secure" type="checkbox" value='<%= function.apply(PropsKeys.MAIL_SESSION_MAIL_STORE_PROTOCOL).equals("pop3s") %>' />
+	<aui:input label="use-a-secure-network-connection" name="pop3Secure" type="checkbox" value='<%= biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_STORE_PROTOCOL, true).equals("pop3s") %>' />
 
-	<aui:input autocomplete="new-password" cssClass="lfr-input-text-container" label="user-name" name="pop3User" type="text" value="<%= function.apply(PropsKeys.MAIL_SESSION_MAIL_POP3_USER) %>" />
+	<aui:input autocomplete="new-password" cssClass="lfr-input-text-container" label="user-name" name="pop3User" type="text" value="<%= biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_POP3_USER, permissionChecker.isOmniadmin()) %>" />
 
 	<%
-	String pop3Password = function.apply(PropsKeys.MAIL_SESSION_MAIL_POP3_PASSWORD);
+	String pop3Password = biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_POP3_PASSWORD, true);
 
 	if (Validator.isNotNull(pop3Password)) {
 		pop3Password = Portal.TEMP_OBFUSCATION_VALUE;
@@ -47,18 +47,18 @@ Function<String, String> function = (String key) -> companyPortletPreferences.ge
 
 	<aui:input autocomplete="new-password" cssClass="lfr-input-text-container" label="password" name="pop3Password" type="password" value="<%= pop3Password %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="outgoing-smtp-server" name="smtpHost" type="text" value="<%= function.apply(PropsKeys.MAIL_SESSION_MAIL_SMTP_HOST) %>" />
+	<aui:input cssClass="lfr-input-text-container" label="outgoing-smtp-server" name="smtpHost" type="text" value="<%= biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_SMTP_HOST, permissionChecker.isOmniadmin()) %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="outgoing-port" name="smtpPort" type="text" value="<%= function.apply(PropsKeys.MAIL_SESSION_MAIL_SMTP_PORT) %>" />
+	<aui:input cssClass="lfr-input-text-container" label="outgoing-port" name="smtpPort" type="text" value="<%= biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_SMTP_PORT, permissionChecker.isOmniadmin()) %>" />
 
-	<aui:input label="use-a-secure-network-connection" name="smtpSecure" type="checkbox" value='<%= function.apply(PropsKeys.MAIL_SESSION_MAIL_TRANSPORT_PROTOCOL).equals("smtps") %>' />
+	<aui:input label="use-a-secure-network-connection" name="smtpSecure" type="checkbox" value='<%= biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_TRANSPORT_PROTOCOL, true).equals("smtps") %>' />
 
-	<aui:input label="enable-starttls" name="smtpStartTLSEnable" type="checkbox" value="<%= GetterUtil.getBoolean(function.apply(PropsKeys.MAIL_SESSION_MAIL_SMTP_STARTTLS_ENABLE)) %>" />
+	<aui:input label="enable-starttls" name="smtpStartTLSEnable" type="checkbox" value="<%= GetterUtil.getBoolean(biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_SMTP_STARTTLS_ENABLE, true)) %>" />
 
-	<aui:input autocomplete="new-password" cssClass="lfr-input-text-container" label="user-name" name="smtpUser" type="text" value="<%= function.apply(PropsKeys.MAIL_SESSION_MAIL_SMTP_USER) %>" />
+	<aui:input autocomplete="new-password" cssClass="lfr-input-text-container" label="user-name" name="smtpUser" type="text" value="<%= biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_SMTP_USER, permissionChecker.isOmniadmin()) %>" />
 
 	<%
-	String smtpPassword = function.apply(PropsKeys.MAIL_SESSION_MAIL_SMTP_PASSWORD);
+	String smtpPassword = biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_SMTP_PASSWORD, true);
 
 	if (Validator.isNotNull(smtpPassword)) {
 		smtpPassword = Portal.TEMP_OBFUSCATION_VALUE;
@@ -67,5 +67,5 @@ Function<String, String> function = (String key) -> companyPortletPreferences.ge
 
 	<aui:input autocomplete="new-password" cssClass="lfr-input-text-container" label="password" name="smtpPassword" type="password" value="<%= smtpPassword %>" />
 
-	<aui:input cssClass="lfr-textarea-container" label="manually-specify-additional-javamail-properties-to-override-the-above-configuration" name="advancedProperties" type="textarea" value="<%= function.apply(PropsKeys.MAIL_SESSION_MAIL_ADVANCED_PROPERTIES) %>" />
+	<aui:input cssClass="lfr-textarea-container" label="manually-specify-additional-javamail-properties-to-override-the-above-configuration" name="advancedProperties" type="textarea" value="<%= biFunction.apply(PropsKeys.MAIL_SESSION_MAIL_ADVANCED_PROPERTIES, true) %>" />
 </aui:fieldset>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-163793

Resolves issue described in [LPS-163793](https://issues.liferay.com/browse/LPS-163793) which was caused by [LPS-157752](https://issues.liferay.com/browse/LPS-157752).  The solution is to only show portal configuration values if the user is an omniadmin.  Instance admins will see blank values if the value comes from portal.properties, be able to update the instance config values, then be able to view those values.