### PR TITLE
LPS-166935 Remove redundant usages of the method getSearchActionURL of analytics-settings-web module

### DIFF
--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/display/context/ChannelManagementToolbarDisplayContext.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/display/context/ChannelManagementToolbarDisplayContext.java
@@ -28,8 +28,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ResourceBundle;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -82,13 +80,6 @@ public class ChannelManagementToolbarDisplayContext
 					LanguageUtil.get(_resourceBundle, "new-property"));
 			}
 		).build();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/display/context/GroupManagementToolbarDisplayContext.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/display/context/GroupManagementToolbarDisplayContext.java
@@ -74,13 +74,6 @@ public class GroupManagementToolbarDisplayContext
 	}
 
 	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
-	}
-
-	@Override
 	public String getSearchContainerId() {
 		return "selectGroups";
 	}

--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/display/context/OrganizationManagementToolbarDisplayContext.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/display/context/OrganizationManagementToolbarDisplayContext.java
@@ -74,13 +74,6 @@ public class OrganizationManagementToolbarDisplayContext
 	}
 
 	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
-	}
-
-	@Override
 	public String getSearchContainerId() {
 		return "selectOrganizations";
 	}

--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/display/context/UserGroupManagementToolbarDisplayContext.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/display/context/UserGroupManagementToolbarDisplayContext.java
@@ -74,13 +74,6 @@ public class UserGroupManagementToolbarDisplayContext
 	}
 
 	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
-	}
-
-	@Override
 	public String getSearchContainerId() {
 		return "selectUserGroups";
 	}


### PR DESCRIPTION
This is an update for [subtask: LPS-166935](https://issues.liferay.com/browse/LPS-166935), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)