### PR TITLE
LPS-167018 Remove redundant usages of the method getSearchActionURL of asset-browser-web module

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserManagementToolbarDisplayContext.java
@@ -203,13 +203,6 @@ public class AssetBrowserManagementToolbarDisplayContext
 	}
 
 	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
-	}
-
-	@Override
 	public String getSearchContainerId() {
 		return "selectAssetEntries";
 	}


### PR DESCRIPTION
This is an update for [subtask: LPS-166935](https://issues.liferay.com/browse/LPS-166935), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)