### PR TITLE
LPS-167303 Avoid duplication in Marketplace_App and Marketplace_Module tables

### DIFF
--- a/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/lpkg/deployer/LPKGDeployerRegistrar.java
+++ b/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/lpkg/deployer/LPKGDeployerRegistrar.java
@@ -264,6 +264,54 @@ public class LPKGDeployerRegistrar {
 	)
 	private Release _release;
 
+	private static class AppKey {
+
+		@Override
+		public boolean equals(Object object) {
+			AppKey appKey = (AppKey)object;
+
+			if (Objects.equals(appKey._title, _title) &&
+				Objects.equals(appKey._description, _description) &&
+				Objects.equals(appKey._category, _category) &&
+				Objects.equals(appKey._iconURL, _iconURL) &&
+				(appKey._required == _required)) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		@Override
+		public int hashCode() {
+			int hashCode = HashUtil.hash(0, _title);
+
+			hashCode = HashUtil.hash(hashCode, _description);
+			hashCode = HashUtil.hash(hashCode, _category);
+			hashCode = HashUtil.hash(hashCode, _iconURL);
+
+			return HashUtil.hash(hashCode, _required);
+		}
+
+		private AppKey(
+			String title, String description, String category, String iconURL,
+			boolean required) {
+
+			_title = title;
+			_description = description;
+			_category = category;
+			_iconURL = iconURL;
+			_required = required;
+		}
+
+		private final String _category;
+		private final String _description;
+		private final String _iconURL;
+		private final boolean _required;
+		private final String _title;
+
+	}
+
 	private static class Tuple {
 
 		@Override

--- a/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/lpkg/deployer/LPKGDeployerRegistrar.java
+++ b/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/lpkg/deployer/LPKGDeployerRegistrar.java
@@ -71,13 +71,17 @@ public class LPKGDeployerRegistrar {
 			return;
 		}
 
-		Map<Long, App> apps = new HashMap<>();
+		Map<AppKey, App> apps = new HashMap<>();
 
 		for (App app :
 				_appLocalService.getApps(
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
 
-			apps.put(app.getRemoteAppId(), app);
+			apps.put(
+				new AppKey(
+					app.getTitle(), app.getDescription(), app.getCategory(),
+					app.getIconURL(), app.isRequired()),
+				app);
 		}
 
 		Map<Long, List<Module>> modules = new HashMap<>();
@@ -103,7 +107,7 @@ public class LPKGDeployerRegistrar {
 	}
 
 	private void _doRegister(
-			Bundle lpkgBundle, Map<Long, App> apps,
+			Bundle lpkgBundle, Map<AppKey, App> apps,
 			Map<Long, List<Module>> modules)
 		throws Exception {
 
@@ -137,7 +141,8 @@ public class LPKGDeployerRegistrar {
 			app = _appLocalService.fetchRemoteApp(remoteAppId);
 		}
 		else {
-			app = apps.get(remoteAppId);
+			app = apps.get(
+				new AppKey(title, description, category, iconURL, required));
 		}
 
 		if ((app != null) &&
@@ -221,7 +226,7 @@ public class LPKGDeployerRegistrar {
 	}
 
 	private void _register(
-		Bundle lpkgBundle, Map<Long, App> apps,
+		Bundle lpkgBundle, Map<AppKey, App> apps,
 		Map<Long, List<Module>> modules) {
 
 		try {

--- a/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/lpkg/deployer/LPKGDeployerRegistrar.java
+++ b/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/lpkg/deployer/LPKGDeployerRegistrar.java
@@ -145,17 +145,15 @@ public class LPKGDeployerRegistrar {
 				new AppKey(title, description, category, iconURL, required));
 		}
 
-		if ((app != null) &&
-			(!Objects.equals(title, app.getTitle()) ||
-			 !Objects.equals(description, app.getDescription()) ||
-			 !Objects.equals(category, app.getCategory()) ||
-			 !Objects.equals(iconURL, app.getIconURL()) ||
-			 (required != app.isRequired()))) {
+		if ((app != null) && (app.getRemoteAppId() != remoteAppId)) {
+			_appLocalService.uninstallApp(app.getRemoteAppId());
 
-			app = null;
+			app.setRemoteAppId(remoteAppId);
+			app.setVersion(version);
+
+			app = _appLocalService.updateApp(app);
 		}
-
-		if (app == null) {
+		else if (app == null) {
 			app = _appLocalService.updateApp(
 				0, remoteAppId, title, description, category, iconURL, version,
 				required, null);


### PR DESCRIPTION
Ticket: [LPS-167303](https://issues.liferay.com/browse/LPS-167303)

This solution was previously discussed on [PTR-3404](https://issues.liferay.com/browse/PTR-3404).

I tested it by deploying the entire Marketplace app, then I did the following steps:
1. Copy the `Liferay Foundation - Liferay Remote App - API.lpkg` and `Liferay Foundation - Liferay Remote App - Impl.lpkg` from a 7.4 U4 bundle to the testing bundle.
2. Start up Liferay, wait for the Marketplace tables to be populated, then shut it down.
3. Copy the `Liferay Foundation - Liferay Remote App - API.lpkg` and `Liferay Foundation - Liferay Remote App - Impl.lpkg` from a 7.4 U20 bundle to the testing bundle, replacing the old files. Also clear osgi/state, temp, and work.
4. Start up Liferay and wait for the Marketplace tables to be populated.
*Testing Results:* The Marketplace_App table are populated with a single instance of each LPKG with the correct updated remoteAppId. The Markeplace_Module table appears correct as well (the `com.liferay.remote.app.client.js` module has been updated to 1.0.7); however, there is one thing that initially surprised me, which is that the entry for `com.liferay.remote.app.uad` was deleted. After further investigation, though, I believe this is the correct behavior because the logs indicated that a module upgrade needed to run for it to be installed properly.