### PR TITLE
LPS-167294 Rename "Account Entry" to "Account" in the UI

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/workflow/AccountEntryWorkflowHandler.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/workflow/AccountEntryWorkflowHandler.java
@@ -17,7 +17,7 @@ package com.liferay.account.internal.workflow;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
@@ -49,7 +49,7 @@ public class AccountEntryWorkflowHandler
 
 	@Override
 	public String getType(Locale locale) {
-		return ResourceActionsUtil.getModelResource(locale, getClassName());
+		return _language.get(locale, "account");
 	}
 
 	@Override
@@ -77,5 +77,8 @@ public class AccountEntryWorkflowHandler
 
 	@Reference
 	private AccountEntryLocalService _accountEntryLocalService;
+
+	@Reference
+	private Language _language;
 
 }


### PR DESCRIPTION
This is an update for [LPS-167294](https://issues.liferay.com/browse/LPS-167294).

<img width="1317" alt="Screen Shot 2022-11-02 at 1 05 53 PM" src="https://user-images.githubusercontent.com/6403097/199567586-d31e7cae-b63f-49b6-b9d3-8f269d5bc56a.png">

<img width="1289" alt="Screen Shot 2022-11-02 at 1 06 35 PM" src="https://user-images.githubusercontent.com/6403097/199567704-798bd0fa-3adb-4b63-a57c-3da48a73ecb0.png">

@david-truong There is a piece of the workflow instance screen that we do not have control over. It will always render the name based on the java resource name:

<img width="379" alt="Screen Shot 2022-11-02 at 1 02 08 PM" src="https://user-images.githubusercontent.com/6403097/199566876-e01bb3e5-2425-40dd-ab26-992dcd436b20.png">


/cc @pei-jung