### PR TITLE
LPS-167667 Remove redundant usages of the method getSearchActionURL from batch-planner-web

### DIFF
--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanManagementToolbarDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanManagementToolbarDisplayContext.java
@@ -29,8 +29,6 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import java.util.List;
 import java.util.Objects;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -111,13 +109,6 @@ public class BatchPlannerPlanManagementToolbarDisplayContext
 	@Override
 	public String getFilterNavigationDropdownItemsLabel() {
 		return LanguageUtil.get(httpServletRequest, "filter-by-action");
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanTemplateManagementToolbarDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanTemplateManagementToolbarDisplayContext.java
@@ -31,8 +31,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -107,13 +105,6 @@ public class BatchPlannerPlanTemplateManagementToolbarDisplayContext
 	@Override
 	public String getFilterNavigationDropdownItemsLabel() {
 		return LanguageUtil.get(httpServletRequest, "filter-by-action");
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [subtask: LPS-167667](https://issues.liferay.com/browse/LPS-167667), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)