### PR TITLE
LPS-167673 Remove redundant usages of the method getSearchActionURL from commerce-account-item-selector-web

### DIFF
--- a/modules/apps/commerce/commerce-account-item-selector-web/src/main/java/com/liferay/commerce/account/item/selector/web/internal/display/context/CommerceAccountGroupAccountItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-account-item-selector-web/src/main/java/com/liferay/commerce/account/item/selector/web/internal/display/context/CommerceAccountGroupAccountItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -50,13 +48,6 @@ public class
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-account-item-selector-web/src/main/java/com/liferay/commerce/account/item/selector/web/internal/display/context/CommerceAccountGroupItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-account-item-selector-web/src/main/java/com/liferay/commerce/account/item/selector/web/internal/display/context/CommerceAccountGroupItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -49,13 +47,6 @@ public class CommerceAccountGroupItemSelectorViewManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/commerce/commerce-account-item-selector-web/src/main/java/com/liferay/commerce/account/item/selector/web/internal/display/context/CommerceAccountItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/commerce/commerce-account-item-selector-web/src/main/java/com/liferay/commerce/account/item/selector/web/internal/display/context/CommerceAccountItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -49,13 +47,6 @@ public class CommerceAccountItemSelectorViewManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [subtask: LPS-167673](https://issues.liferay.com/browse/LPS-167673), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)