### PR TITLE
LPS-167693 Remove redundant usages of the method getSearchActionURL from depot-web

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSelectRoleManagementToolbarDisplayContext.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminSelectRoleManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -55,13 +53,6 @@ public class DepotAdminSelectRoleManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "depotAdminSelectRoleManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [subtask: LPS-167693](https://issues.liferay.com/browse/LPS-167693), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)