### PR TITLE
LPS-167818 Remove redundant usages of the method getSearchActionURL from knowledge-base-web

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleItemSelectorViewManagementToolbarDisplayContext.java
@@ -23,8 +23,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.util.Objects;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -58,13 +56,6 @@ public class KBArticleItemSelectorViewManagementToolbarDisplayContext
 		).setParameter(
 			"scope", StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [subtask: LPS-167818](https://issues.liferay.com/browse/LPS-167818), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)