### PR TITLE
LPS-167849 Remove redundant usages of the method getSearchActionURL from organizations-item-selector-web

### DIFF
--- a/modules/apps/organizations/organizations-item-selector-web/src/main/java/com/liferay/organizations/item/selector/web/internal/display/context/OrganizationItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/organizations/organizations-item-selector-web/src/main/java/com/liferay/organizations/item/selector/web/internal/display/context/OrganizationItemSelectorViewManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -51,13 +49,6 @@ public class OrganizationItemSelectorViewManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [subtask: LPS-167849](https://issues.liferay.com/browse/LPS-167849), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)