### PR TITLE
LPS-167854 Remove redundant usages of the method getSearchActionURL from site-browser-web

### DIFF
--- a/modules/apps/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserManagementToolbarDisplayContext.java
@@ -22,8 +22,6 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
 import java.util.Objects;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -58,13 +56,6 @@ public class SiteBrowserManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "siteBrowserWebManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [subtask: LPS-167854](https://issues.liferay.com/browse/LPS-167854), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)