### PR TITLE
LPS-167861 Remove redundant usages of the method getSearchActionURL from the app site

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/OrganizationsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/OrganizationsManagementToolbarDisplayContext.java
@@ -35,8 +35,6 @@ import com.liferay.site.memberships.web.internal.util.GroupUtil;
 
 import java.util.List;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -149,13 +147,6 @@ public class OrganizationsManagementToolbarDisplayContext
 	@Override
 	public String getInfoPanelId() {
 		return "infoPanelId";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/RolesManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/RolesManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -57,13 +55,6 @@ public class RolesManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "rolesManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectOrganizationsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectOrganizationsManagementToolbarDisplayContext.java
@@ -20,8 +20,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -56,13 +54,6 @@ public class SelectOrganizationsManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "organizationsManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectRolesManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectRolesManagementToolbarDisplayContext.java
@@ -20,8 +20,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -56,13 +54,6 @@ public class SelectRolesManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "rolesManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUserGroupsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUserGroupsManagementToolbarDisplayContext.java
@@ -20,8 +20,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -55,13 +53,6 @@ public class SelectUserGroupsManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "userGroupsManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersManagementToolbarDisplayContext.java
@@ -20,8 +20,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -55,13 +53,6 @@ public class SelectUsersManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "usersManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserGroupRolesManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserGroupRolesManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -57,13 +55,6 @@ public class UserGroupRolesManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "userGroupGroupRoleRoleManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserGroupsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserGroupsManagementToolbarDisplayContext.java
@@ -260,13 +260,6 @@ public class UserGroupsManagementToolbarDisplayContext
 	}
 
 	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
-	}
-
-	@Override
 	public String getSearchContainerId() {
 		return "userGroups";
 	}

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserRolesManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UserRolesManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -57,13 +55,6 @@ public class UserRolesManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "userGroupRoleRoleManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UsersManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/UsersManagementToolbarDisplayContext.java
@@ -284,13 +284,6 @@ public class UsersManagementToolbarDisplayContext
 	}
 
 	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
-	}
-
-	@Override
 	public String getSearchContainerId() {
 		return "users";
 	}

--- a/modules/apps/site/site-my-sites-web/src/main/java/com/liferay/site/my/sites/web/internal/display/context/SiteMySitesManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-my-sites-web/src/main/java/com/liferay/site/my/sites/web/internal/display/context/SiteMySitesManagementToolbarDisplayContext.java
@@ -20,8 +20,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -55,13 +53,6 @@ public class SiteMySitesManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "siteMySitesWebManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUserGroupsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUserGroupsManagementToolbarDisplayContext.java
@@ -32,8 +32,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -131,13 +129,6 @@ public class EditSiteTeamAssignmentsUserGroupsManagementToolbarDisplayContext
 
 			return null;
 		}
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUsersManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/EditSiteTeamAssignmentsUsersManagementToolbarDisplayContext.java
@@ -32,8 +32,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -131,13 +129,6 @@ public class EditSiteTeamAssignmentsUsersManagementToolbarDisplayContext
 
 			return null;
 		}
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectTeamManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectTeamManagementToolbarDisplayContext.java
@@ -20,8 +20,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -55,13 +53,6 @@ public class SelectTeamManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "selectTeamWebManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectUserGroupsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectUserGroupsManagementToolbarDisplayContext.java
@@ -20,8 +20,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -55,13 +53,6 @@ public class SelectUserGroupsManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "selectUserGroupsWebManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectUsersManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SelectUsersManagementToolbarDisplayContext.java
@@ -20,8 +20,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -55,13 +53,6 @@ public class SelectUsersManagementToolbarDisplayContext
 	@Override
 	public String getComponentId() {
 		return "selectUsersWebManagementToolbar";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SiteTeamsManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/display/context/SiteTeamsManagementToolbarDisplayContext.java
@@ -36,8 +36,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -111,13 +109,6 @@ public class SiteTeamsManagementToolbarDisplayContext
 					LanguageUtil.get(httpServletRequest, "add-team"));
 			}
 		).build();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [subtask: LPS-167861](https://issues.liferay.com/browse/LPS-167861), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)