### PR TITLE
LPS-168020 Remove redundant usages of the method getSearchActionURL from the app archived

### DIFF
--- a/modules/apps/archived/sync-web/src/main/java/com/liferay/sync/web/internal/display/context/DevicesManagementToolbarDisplayContext.java
+++ b/modules/apps/archived/sync-web/src/main/java/com/liferay/sync/web/internal/display/context/DevicesManagementToolbarDisplayContext.java
@@ -22,8 +22,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.sync.model.SyncDevice;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -50,13 +48,6 @@ public class DevicesManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/archived/sync-web/src/main/java/com/liferay/sync/web/internal/display/context/SitesManagementToolbarDisplayContext.java
+++ b/modules/apps/archived/sync-web/src/main/java/com/liferay/sync/web/internal/display/context/SitesManagementToolbarDisplayContext.java
@@ -27,8 +27,6 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
 import java.util.List;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -91,13 +89,6 @@ public class SitesManagementToolbarDisplayContext
 		).setKeywords(
 			StringPool.BLANK
 		).buildString();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [subtask: LPS-168020](https://issues.liferay.com/browse/LPS-168020), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)