### PR TITLE
LPS-168022 Remove redundant usages of the method getSearchActionURL from the app trash

### DIFF
--- a/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashContainerManagementToolbarDisplayContext.java
+++ b/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashContainerManagementToolbarDisplayContext.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -62,13 +60,6 @@ public class TrashContainerManagementToolbarDisplayContext
 	@Override
 	public String getInfoPanelId() {
 		return "infoPanelId";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override

--- a/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashManagementToolbarDisplayContext.java
+++ b/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashManagementToolbarDisplayContext.java
@@ -42,8 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -173,13 +171,6 @@ public class TrashManagementToolbarDisplayContext
 	@Override
 	public String getInfoPanelId() {
 		return "infoPanelId";
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [subtask: LPS-168022](https://issues.liferay.com/browse/LPS-168022), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)