### PR TITLE
LPS-168027 Remove redundant usages of the method getSearchActionURL from the app site-navigation

### DIFF
--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminManagementToolbarDisplayContext.java
@@ -35,8 +35,6 @@ import com.liferay.site.navigation.model.SiteNavigationMenu;
 
 import java.util.List;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -122,13 +120,6 @@ public class SiteNavigationAdminManagementToolbarDisplayContext
 					LanguageUtil.get(httpServletRequest, "add"));
 			}
 		).build();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [subtask: LPS-168027](https://issues.liferay.com/browse/LPS-168027), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)