### PR TITLE
LPS-168028 Remove redundant usages of the method getSearchActionURL from the app style-book

### DIFF
--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/StyleBookManagementToolbarDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/StyleBookManagementToolbarDisplayContext.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.portlet.PortletURL;
 import javax.portlet.ResourceURL;
 
 import javax.servlet.http.HttpServletRequest;
@@ -174,13 +173,6 @@ public class StyleBookManagementToolbarDisplayContext
 					LanguageUtil.get(httpServletRequest, "add"));
 			}
 		).build();
-	}
-
-	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [subtask: LPS-168028](https://issues.liferay.com/browse/LPS-168028), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)