### PR TITLE
LPS-168030 Remove redundant usages of the method getSearchActionURL from the app template

### DIFF
--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/display/context/WidgetTemplatesManagementToolbarDisplayContext.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/display/context/WidgetTemplatesManagementToolbarDisplayContext.java
@@ -170,13 +170,6 @@ public class WidgetTemplatesManagementToolbarDisplayContext
 	}
 
 	@Override
-	public String getSearchActionURL() {
-		PortletURL searchActionURL = getPortletURL();
-
-		return searchActionURL.toString();
-	}
-
-	@Override
 	public String getSearchContainerId() {
 		return "ddmTemplates";
 	}


### PR DESCRIPTION
This is an update for [subtask: LPS-168030](https://issues.liferay.com/browse/LPS-168030), [LPS-161233](https://issues.liferay.com/browse/LPS-161233)