### PR TITLE
[TS] LPS-168597 Do not show if the user does not have a profile page to link to

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/product/navigation/personal/menu/MyProfilePersonalMenuEntry.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/product/navigation/personal/menu/MyProfilePersonalMenuEntry.java
@@ -104,10 +104,13 @@ public class MyProfilePersonalMenuEntry implements PersonalMenuEntry {
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_POWER_USER_REQUIRED &&
-			!roleLocalService.hasUserRole(
-				themeDisplay.getUserId(), themeDisplay.getCompanyId(),
-				RoleConstants.POWER_USER, true)) {
+		User user = themeDisplay.getUser();
+
+		if (Validator.isNull(user.getDisplayURL(themeDisplay, false)) ||
+			(PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_POWER_USER_REQUIRED &&
+			 !roleLocalService.hasUserRole(
+				 themeDisplay.getUserId(), themeDisplay.getCompanyId(),
+				 RoleConstants.POWER_USER, true))) {
 
 			return false;
 		}


### PR DESCRIPTION
**Steps to Reproduce**

1. Set layout.user.public.layouts.auto.create=false in portal-ext.properties
2. Sign in
3. Click on user icon to open personal menu

**Expected Results**
There is no My Profile link since there is no profile page.

**Actual Results**
There is a My Profile link and clicking it does nothing.

When layout.user.public.layouts.auto.create=false is set there is still the possibility for some users to have profile pages through User Groups. This fix allows those users to see the My Profile link while those who do not have pages do not see the link.

Please let me know if there are any issues or if there is a better way to resolve this issue.