### PR TITLE
LPS-169033 Trying to associate a user to an account before creating an account make the portlet break

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountEntryAccountGroupsScreenNavigationCategory.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountEntryAccountGroupsScreenNavigationCategory.java
@@ -68,7 +68,7 @@ public class AccountEntryAccountGroupsScreenNavigationCategory
 
 	@Override
 	public boolean isVisible(User user, AccountEntry accountEntry) {
-		if (accountEntry == null) {
+		if (accountEntry.isNew()) {
 			return false;
 		}
 

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountEntryAddressesScreenNavigationCategory.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountEntryAddressesScreenNavigationCategory.java
@@ -67,7 +67,7 @@ public class AccountEntryAddressesScreenNavigationCategory
 
 	@Override
 	public boolean isVisible(User user, AccountEntry accountEntry) {
-		if (accountEntry == null) {
+		if (accountEntry.isNew()) {
 			return false;
 		}
 

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountEntryOrganizationsScreenNavigationCategory.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountEntryOrganizationsScreenNavigationCategory.java
@@ -67,7 +67,7 @@ public class AccountEntryOrganizationsScreenNavigationCategory
 
 	@Override
 	public boolean isVisible(User user, AccountEntry accountEntry) {
-		if (accountEntry == null) {
+		if (accountEntry.isNew()) {
 			return false;
 		}
 

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountEntryRolesScreenNavigationCategory.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountEntryRolesScreenNavigationCategory.java
@@ -69,7 +69,7 @@ public class AccountEntryRolesScreenNavigationCategory
 
 	@Override
 	public boolean isVisible(User user, AccountEntry accountEntry) {
-		if ((accountEntry == null) ||
+		if (accountEntry.isNew() ||
 			!AllowEditAccountRoleThreadLocal.isAllowEditAccountRole() ||
 			Objects.equals(
 				accountEntry.getType(),

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountEntryUsersScreenNavigationCategory.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountEntryUsersScreenNavigationCategory.java
@@ -68,7 +68,7 @@ public class AccountEntryUsersScreenNavigationCategory
 
 	@Override
 	public boolean isVisible(User user, AccountEntry accountEntry) {
-		if ((accountEntry == null) ||
+		if (accountEntry.isNew() ||
 			!Objects.equals(
 				accountEntry.getType(),
 				AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS)) {

--- a/modules/apps/commerce/commerce-account-web/src/main/java/com/liferay/commerce/account/web/internal/frontend/taglib/servlet/taglib/AccountEntryCommerceChannelDefaultsScreenNavigationCategory.java
+++ b/modules/apps/commerce/commerce-account-web/src/main/java/com/liferay/commerce/account/web/internal/frontend/taglib/servlet/taglib/AccountEntryCommerceChannelDefaultsScreenNavigationCategory.java
@@ -95,7 +95,7 @@ public class AccountEntryCommerceChannelDefaultsScreenNavigationCategory
 
 	@Override
 	public boolean isVisible(User user, AccountEntry accountEntry) {
-		if ((accountEntry == null) ||
+		if (accountEntry.isNew() ||
 			!Objects.equals(
 				accountEntry.getType(),
 				AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS)) {


### PR DESCRIPTION
This is an update for [LPS-169033](https://issues.liferay.com/browse/LPS-169033).

442bbfb17b54 caused this issue. All the account tabs were visible during account creation, which allows for all sorts of issues.

@patriciajeanperez if possible can we add test coverage to assert that the tabs are only visible after the account has been created?

/cc @pei-jung @ChrisKian @david-truong @gislayne-vitorino