### PR TITLE
LPS-166023 Instance mail settings value should be inherited with DB Partition

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -124,6 +124,7 @@ import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PrefsPropsUtil;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portlet.PortalPreferencesWrapper;
 
 import java.io.File;
 import java.io.IOException;
@@ -220,8 +221,20 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			DBPartitionUtil.setDefaultCompanyId(company.getCompanyId());
 		}
 
+		com.liferay.portal.kernel.portlet.PortalPreferences
+			systemPortalPreferences = null;
+
 		boolean newDBPartitionAdded = DBPartitionUtil.addDBPartition(
 			company.getCompanyId());
+
+		if (newDBPartitionAdded) {
+			PortalPreferencesWrapper portalPreferencesWrapper =
+				(PortalPreferencesWrapper)PrefsPropsUtil.getPreferences(
+					PortletKeys.PREFS_OWNER_ID_DEFAULT);
+
+			systemPortalPreferences =
+				portalPreferencesWrapper.getPortalPreferencesImpl();
+		}
 
 		SafeCloseable safeCloseable =
 			CompanyThreadLocal.setInitializingCompanyIdWithSafeCloseable(
@@ -242,6 +255,13 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			if (newDBPartitionAdded) {
 				_dlFileEntryTypeLocalService.
 					createBasicDocumentDLFileEntryType();
+			}
+
+			if (systemPortalPreferences != null) {
+				_portalPreferencesLocalService.updatePreferences(
+					PortletKeys.PREFS_OWNER_ID_DEFAULT,
+					PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+					systemPortalPreferences);
 			}
 
 			String name = webId;

--- a/portal-impl/src/com/liferay/portlet/PortalPreferencesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortalPreferencesImpl.java
@@ -15,18 +15,21 @@
 package com.liferay.portlet;
 
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.portal.db.partition.DBPartitionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.PortletConstants;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.persistence.PortalPreferenceValueUtil;
 import com.liferay.portal.kernel.service.persistence.PortalPreferencesUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.simple.Element;
@@ -393,8 +396,19 @@ public class PortalPreferencesImpl
 
 	public void store() throws IOException {
 		try {
-			PortalPreferencesLocalServiceUtil.updatePreferences(
-				getOwnerId(), getOwnerType(), this);
+			if (!DBPartitionUtil.isPartitionEnabled() ||
+				((getOwnerId() != PortletKeys.PREFS_OWNER_ID_DEFAULT) &&
+				 (getOwnerType() == PortletKeys.PREFS_OWNER_TYPE_COMPANY))) {
+
+				PortalPreferencesLocalServiceUtil.updatePreferences(
+					getOwnerId(), getOwnerType(), this);
+
+				return;
+			}
+
+			CompanyLocalServiceUtil.forEachCompany(
+				company -> PortalPreferencesLocalServiceUtil.updatePreferences(
+					getOwnerId(), getOwnerType(), this));
 		}
 		catch (Throwable throwable) {
 			throw new IOException(throwable);


### PR DESCRIPTION
Hi,
This is the PR for the ticket https://issues.liferay.com/browse/LPS-166023. Please help to review this and leave your comments.

**Note:**
- The actually result of [LPS-166023](https://issues.liferay.com/browse/LPS-166023) is affected by [LPS-163793](https://issues.liferay.com/browse/LPS-163793). Instead of localhost, it is blank. I have confirmed with the reporter and she said that the expected result of [LPS-166023](https://issues.liferay.com/browse/LPS-166023) should not be affected. The inherited should still inherit.
- The idea of this fix is to copy the value of the System Portal Reference for all Database Partitions and also to update them when the System Portal Reference is updated.

Thank you
CC: @tototrinh