### PR TITLE
LPS-170474

### DIFF
--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryLocalServiceTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryLocalServiceTest.java
@@ -54,6 +54,7 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -366,15 +367,22 @@ public class AccountEntryLocalServiceTest {
 
 	@Test
 	public void testAddAccountEntryWithWorkflowEnabled() throws Exception {
-		_enableWorkflow();
+		String originalName = PrincipalThreadLocal.getName();
 
-		User user = UserTestUtil.addUser();
+		try {
+			_enableWorkflow();
 
-		AccountEntry accountEntry = AccountEntryTestUtil.addAccountEntry(
-			AccountEntryArgs.withOwner(user));
+			User user = UserTestUtil.addUser();
 
-		_assertStatus(accountEntry, WorkflowConstants.STATUS_PENDING, user);
-		Assert.assertTrue(_hasWorkflowInstance(accountEntry));
+			AccountEntry accountEntry = AccountEntryTestUtil.addAccountEntry(
+				AccountEntryArgs.withOwner(user));
+
+			_assertStatus(accountEntry, WorkflowConstants.STATUS_PENDING, user);
+			Assert.assertTrue(_hasWorkflowInstance(accountEntry));
+		}
+		finally {
+			PrincipalThreadLocal.setName(originalName);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Hi @pei-jung,
Following Brian Chan's feedback, I've updated the code to make it is obvious. Please help me review this again and leave your comment.
Ticket: https://issues.liferay.com/browse/LPS-170474
Previous PRs: 
https://github.com/brianchandotcom/liferay-portal/pull/127626
https://github.com/liferay-usm/liferay-portal/pull/910
Explanation:
After [enable the workflow](https://github.com/liferay/liferay-portal/blob/master/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryLocalServiceTest.java#L369), userId will be set as Name to the PrincipalThreadLocal [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/service/test/AccountEntryLocalServiceTest.java#L371) and this value isn't reset after the end of the test function. It means PrincipalThreadLocal.getName() always return userId value of User that have been deleted and that's why the error occurs on testSearchByAccountGroupIds().
Solution: 
Restore PrincipalThreadLocal to original state.
Thanks.