### PR TITLE
LPS-171281 When accessing Process Builder on the Instance Virtual an error message is displayed

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/WorkflowPortletResourcePermission.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/WorkflowPortletResourcePermission.java
@@ -78,8 +78,7 @@ public class WorkflowPortletResourcePermission
 			return true;
 		}
 
-		return permissionChecker.hasPermission(
-			groupId, WorkflowConstants.RESOURCE_NAME, 0, actionId);
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Hi team,
Please help review this PR and leave your comments. Thanks.
Ticket: https://issues.liferay.com/browse/LPS-171281

Note:

We don't define actions with [WorkflowConstants.RESOURCE_NAME](https://github.com/liferay/liferay-portal-ee/blob/master/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowConstants.java#L86) or with WorkflowDefinition model so the issue will occur [here](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/security/permission/resource/WorkflowPortletResourcePermission.java#L81-L82).
Solution is to update the contains function based on the logic before applying [LPS-167189](https://issues.liferay.com/browse/LPS-167189).
Thanks,
Loc
cc:@tototrinh