### PR TITLE
LPS-173854 Headless API doesn't return clear error message for duplicate organizations

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/jaxrs/exception/mapper/DuplicateOrganizationExceptionMapper.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/jaxrs/exception/mapper/DuplicateOrganizationExceptionMapper.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.admin.user.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.kernel.exception.DuplicateOrganizationException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Admin.User)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Admin.User.DuplicateOrganizationExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class DuplicateOrganizationExceptionMapper
+	extends BaseExceptionMapper<DuplicateOrganizationException> {
+
+	@Override
+	protected Problem getProblem(
+		DuplicateOrganizationException duplicateOrganizationException) {
+
+		return new Problem(
+			Response.Status.BAD_REQUEST,
+			duplicateOrganizationException.getMessage());
+	}
+
+}


### PR DESCRIPTION
This is an update for [LPS-173854](https://issues.liferay.com/browse/LPS-173854).<br/><br/>/cc @pei-jung @ChrisKian @patriciajeanperez @david-truong @gislayne-vitorino