### PR TITLE
LPS-168768 Roles don't use h# tags in search container descriptive view

### DIFF
--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/search_columns.jspf
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/search_columns.jspf
@@ -27,17 +27,17 @@ RoleTypeContributor currentRoleTypeContributor = RoleTypeContributorRetrieverUti
 		<liferay-ui:search-container-column-text
 			colspan="<%= 2 %>"
 		>
-			<h5>
+			<div class="list-group-title">
 				<aui:a href="<%= (rowURL != null) ? rowURL.toString() : null %>"><%= HtmlUtil.escape(role.getTitle(locale)) %></aui:a>
-			</h5>
+			</div>
 
-			<h6 class="text-default">
+			<div class="list-group-text">
 				<span><%= HtmlUtil.escape(role.getDescription(locale)) %></span>
-			</h6>
+			</div>
 
-			<h6 class="text-default">
+			<div class="list-group-subtext">
 				<span><%= roleDisplayContext.getAssigneesMessage(role) %></span>
-			</h6>
+			</div>
 		</liferay-ui:search-container-column-text>
 
 		<liferay-ui:search-container-column-jsp


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168768

This updates the markup to use `div` instead of `h#` tags. I updated the classes to follow Clay's hierarchy for text in list-group. It changed the color of the 2nd line text to `$gray-900` from `$secondary`. I need to check with Lexicon to see if this is correct. It doesn't look like it from https://liferay.design/lexicon/core-components/List/. We will update it in Clay and it will update when Clay is updated.

![roles-admin](https://user-images.githubusercontent.com/788266/216154083-4e4f005c-4f6b-4f37-8002-eb76af754347.jpg)
