### PR TITLE
LPS-168556 Users Contact add button should announce the group title

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
@@ -26,7 +26,6 @@ List<EmailAddress> emailAddresses = EmailAddressServiceUtil.getEmailAddresses(cl
 %>
 
 <clay:content-row
-	containerElement="h3"
 	cssClass="sheet-subtitle"
 >
 	<clay:content-col
@@ -37,11 +36,11 @@ List<EmailAddress> emailAddresses = EmailAddressServiceUtil.getEmailAddresses(cl
 
 	<clay:content-col>
 		<span class="heading-end">
-			<liferay-ui:icon
-				label="<%= true %>"
-				linkCssClass="add-email-address-link btn btn-secondary btn-sm"
-				message="add"
-				url='<%=
+			<clay:link
+				aria-label='<%= LanguageUtil.format(request, "add-x", "additional-email-addresses") %>'
+				cssClass="add-email-address-link btn btn-secondary btn-sm"
+				displayType="null"
+				href='<%=
 					PortletURLBuilder.createRenderURL(
 						liferayPortletResponse
 					).setMVCPath(
@@ -54,6 +53,8 @@ List<EmailAddress> emailAddresses = EmailAddressServiceUtil.getEmailAddresses(cl
 						"classPK", classPK
 					).buildString()
 				%>'
+				label="add"
+				role="button"
 			/>
 		</span>
 	</clay:content-col>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
@@ -27,7 +27,6 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 
 <clay:sheet-header>
 	<clay:content-row
-		containerElement="h2"
 		cssClass="sheet-title"
 	>
 		<clay:content-col
@@ -38,11 +37,11 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 
 		<clay:content-col>
 			<span class="heading-end">
-				<liferay-ui:icon
-					label="<%= true %>"
-					linkCssClass="add-address-link btn btn-secondary btn-sm"
-					message="add"
-					url='<%=
+				<clay:link
+					aria-label='<%= LanguageUtil.format(request, "add-x", "addresses") %>'
+					cssClass="add-address-link btn btn-secondary btn-sm"
+					displayType="null"
+					href='<%=
 						PortletURLBuilder.createRenderURL(
 							liferayPortletResponse
 						).setMVCPath(
@@ -55,6 +54,8 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 							"classPK", classPK
 						).buildString()
 					%>'
+					label="add"
+					role="button"
 				/>
 			</span>
 		</clay:content-col>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
@@ -26,7 +26,6 @@ List<Phone> phones = PhoneServiceUtil.getPhones(className, classPK);
 %>
 
 <clay:content-row
-	containerElement="h3"
 	cssClass="sheet-subtitle"
 >
 	<clay:content-col
@@ -37,11 +36,11 @@ List<Phone> phones = PhoneServiceUtil.getPhones(className, classPK);
 
 	<clay:content-col>
 		<span class="heading-end">
-			<liferay-ui:icon
-				label="<%= true %>"
-				linkCssClass="add-phone-number-link btn btn-secondary btn-sm"
-				message="add"
-				url='<%=
+			<clay:link
+				aria-label='<%= LanguageUtil.format(request, "add-x", "phone-numbers") %>'
+				cssClass="add-phone-number-link btn btn-secondary btn-sm"
+				displayType="null"
+				href='<%=
 					PortletURLBuilder.createRenderURL(
 						liferayPortletResponse
 					).setMVCPath(
@@ -54,6 +53,8 @@ List<Phone> phones = PhoneServiceUtil.getPhones(className, classPK);
 						"classPK", classPK
 					).buildString()
 				%>'
+				label="add"
+				role="button"
 			/>
 		</span>
 	</clay:content-col>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
@@ -26,7 +26,6 @@ List<Website> websites = WebsiteServiceUtil.getWebsites(className, classPK);
 %>
 
 <clay:content-row
-	containerElement="h3"
 	cssClass="sheet-subtitle"
 >
 	<clay:content-col
@@ -37,11 +36,11 @@ List<Website> websites = WebsiteServiceUtil.getWebsites(className, classPK);
 
 	<clay:content-col>
 		<span class="heading-end">
-			<liferay-ui:icon
-				label="<%= true %>"
-				linkCssClass="add-website-link btn btn-secondary btn-sm"
-				message="add"
-				url='<%=
+			<clay:link
+				aria-label='<%= LanguageUtil.format(request, "add-x", "websites") %>'
+				cssClass="add-website-link btn btn-secondary btn-sm"
+				displayType="null"
+				href='<%=
 					PortletURLBuilder.createRenderURL(
 						liferayPortletResponse
 					).setMVCPath(
@@ -54,6 +53,8 @@ List<Website> websites = WebsiteServiceUtil.getWebsites(className, classPK);
 						"classPK", classPK
 					).buildString()
 				%>'
+				label="add"
+				role="button"
 			/>
 		</span>
 	</clay:content-col>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/contact_information.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/contact_information.jsp
@@ -53,19 +53,19 @@ request.setAttribute("contact_information.jsp-classPK", selContactId);
 </clay:sheet-section>
 
 <clay:sheet-section>
-	<h3 class="sheet-subtitle"><liferay-ui:message key="instant-messenger" /></h3>
+	<div class="sheet-subtitle"><liferay-ui:message key="instant-messenger" /></div>
 
 	<liferay-util:include page="/user/instant_messenger.jsp" servletContext="<%= application %>" />
 </clay:sheet-section>
 
 <clay:sheet-section>
-	<h3 class="sheet-subtitle"><liferay-ui:message key="sms" /></h3>
+	<div class="sheet-subtitle"><liferay-ui:message key="sms" /></div>
 
 	<liferay-util:include page="/user/sms.jsp" servletContext="<%= application %>" />
 </clay:sheet-section>
 
 <clay:sheet-section>
-	<h3 class="sheet-subtitle"><liferay-ui:message key="social-network" /></h3>
+	<div class="sheet-subtitle"><liferay-ui:message key="social-network" /></div>
 
 	<liferay-util:include page="/user/social_network.jsp" servletContext="<%= application %>" />
 </clay:sheet-section>


### PR DESCRIPTION
LPS-168546 Users Contact use div instead of h# to prevent buttons from being read as "headling level".

https://issues.liferay.com/browse/LPS-168556
https://issues.liferay.com/browse/LPS-168546