### PR TITLE
LPS-169813 The Add Entry button is half hided when there are more entries

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
@@ -115,6 +115,18 @@ export default function propsTransformer({
 
 			if (action === 'inviteAccountUsers') {
 				openModal({
+					buttons: [
+						{
+							displayType: 'secondary',
+							label: Liferay.Language.get('cancel'),
+							type: 'cancel',
+						},
+						{
+							formId: `${portletNamespace}fm`,
+							label: Liferay.Language.get('invite'),
+							type: 'submit',
+						},
+					],
 					containerProps: {
 						className: 'modal-height-xl',
 					},

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/AccountUsersManagementToolbarPropsTransformer.js
@@ -122,7 +122,7 @@ export default function propsTransformer({
 							type: 'cancel',
 						},
 						{
-							formId: `${portletNamespace}fm`,
+							formId: `${portletNamespace}inviteUserForm`,
 							label: Liferay.Language.get('invite'),
 							type: 'submit',
 						},

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/InviteUsersForm.tsx
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/InviteUsersForm.tsx
@@ -210,16 +210,6 @@ function InviteUsersForm({
 					{Liferay.Language.get('add-entry')}
 				</ClayButton>
 			</ClayLayout.SheetFooter>
-
-			<ClayLayout.SheetFooter className="dialog-footer">
-				<ClayButton displayType="primary" onClick={submitForm}>
-					{Liferay.Language.get('invite')}
-				</ClayButton>
-
-				<ClayButton displayType="secondary" onClick={closeModal}>
-					{Liferay.Language.get('cancel')}
-				</ClayButton>
-			</ClayLayout.SheetFooter>
 		</ClayForm>
 	);
 }

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/InviteUsersForm.tsx
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/InviteUsersForm.tsx
@@ -17,7 +17,7 @@ import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import {sub} from 'frontend-js-web';
-import React, {MouseEventHandler, useState} from 'react';
+import React, {FormEventHandler, useState} from 'react';
 
 import InviteUserFormGroup from './InviteUsersFormGroup';
 import {InputGroup, MultiSelectItem, ValidatableMultiSelectItem} from './types';
@@ -129,7 +129,7 @@ function InviteUsersForm({
 		setInputGroups([...inputGroups]);
 	}
 
-	const submitForm: MouseEventHandler<HTMLButtonElement> = async (event) => {
+	const submitForm: FormEventHandler<HTMLFormElement> = async (event) => {
 		event.preventDefault();
 
 		const form = document.querySelector(`#${formId}`) as HTMLFormElement;
@@ -170,7 +170,11 @@ function InviteUsersForm({
 	};
 
 	return (
-		<ClayForm className="lfr-form-content" id={formId}>
+		<ClayForm
+			className="lfr-form-content"
+			id={formId}
+			onSubmit={submitForm}
+		>
 			{inputGroups.map((inputGroup, index) => (
 				<InviteUserFormGroup
 					accountRoles={inputGroup.accountRoles}

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/InviteUsersForm.tsx
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/InviteUsersForm.tsx
@@ -132,11 +132,11 @@ function InviteUsersForm({
 	const submitForm: FormEventHandler<HTMLFormElement> = async (event) => {
 		event.preventDefault();
 
-		const form = document.querySelector(`#${formId}`) as HTMLFormElement;
+		const form = event.currentTarget;
 
-		const error = form?.querySelector('.has-error');
+		const error = form.querySelector('.has-error');
 
-		if (!error && form) {
+		if (!error) {
 			const formData = new FormData(form);
 
 			formData.append(

--- a/modules/apps/account/account-test/src/testFunctional/macros/Account.macro
+++ b/modules/apps/account/account-test/src/testFunctional/macros/Account.macro
@@ -1075,6 +1075,8 @@ definition {
 			locator1 = "TextInput#ANY",
 			value1 = "\RETURN");
 
+		SelectFrameTop();
+
 		Button.click(button = "Invite");
 	}
 


### PR DESCRIPTION
Resent from https://github.com/liferay-usm/liferay-portal/pull/961

From @drewbrokke:

This is an update for [LPS-169813](https://issues.liferay.com/browse/LPS-169813).

@SelenaAungst there were two primary reasons the code was not working:

1. After removing the buttons from `InviteUsersForm`, the `onSubmit` function was no longer being used anywhere. The way to solve this was to assign the function to the `onSubmit` attribute of the `ClayForm`
2. The modal submit button added to `AccountUsersManagementToolbarPropsTransformer` was using the wrong `formId` value. This meant that the [Modal.js code that tries to retrieve and submit the form](https://github.com/drewbrokke/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js?plain=1#L116) (thus triggering the `onSubmit` function from the previous point) would not find the correct one. The solution to this was to instead use the value found in [`InviteUserForm#54`](https://github.com/drewbrokke/liferay-portal/blob/master/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/InviteUsersForm.tsx?plain=1#L54)

Please let me know if you have any questions or concerns with what you see here. Thanks!

/cc @pei-jung @ChrisKian @patriciajeanperez @david-truong @gislayne-vitorino