### PR TITLE
LPS-168532 User Profile and Dashboard links should announce more descriptive text on screen readers

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
@@ -95,6 +95,10 @@ public class LinkTag extends BaseContainerTag {
 		return _icon;
 	}
 
+	public String getIconAfter() {
+		return _iconAfter;
+	}
+
 	public String getLabel() {
 		return _label;
 	}
@@ -151,6 +155,10 @@ public class LinkTag extends BaseContainerTag {
 		_icon = icon;
 	}
 
+	public void setIconAfter(String iconAfter) {
+		_iconAfter = iconAfter;
+	}
+
 	public void setLabel(String label) {
 		_label = label;
 	}
@@ -187,6 +195,7 @@ public class LinkTag extends BaseContainerTag {
 		_fontSize = null;
 		_href = null;
 		_icon = null;
+		_iconAfter = null;
 		_label = null;
 		_monospaced = false;
 		_outline = false;
@@ -213,6 +222,7 @@ public class LinkTag extends BaseContainerTag {
 		props.put("displayType", _displayType);
 		props.put("fontSize", _fontSize);
 		props.put("icon", _icon);
+		props.put("iconAfter", _iconAfter);
 		props.put("weight", _weight);
 
 		if (Validator.isNotNull(_label)) {
@@ -284,7 +294,9 @@ public class LinkTag extends BaseContainerTag {
 	protected int processStartTag() throws Exception {
 		super.processStartTag();
 
-		if (Validator.isNotNull(_icon) || Validator.isNotNull(_label)) {
+		if (Validator.isNotNull(_icon) || Validator.isNotNull(_iconAfter) ||
+			Validator.isNotNull(_label)) {
+
 			JspWriter jspWriter = pageContext.getOut();
 
 			if (Validator.isNotNull(_icon)) {
@@ -307,6 +319,18 @@ public class LinkTag extends BaseContainerTag {
 				jspWriter.write(HtmlUtil.escape(label));
 			}
 
+			if (Validator.isNotNull(_iconAfter)) {
+				IconTag iconAfterTag = new IconTag();
+
+				if (Validator.isNotNull(_label)) {
+					iconAfterTag.setCssClass("inline-item inline-item-after");
+				}
+
+				iconAfterTag.setSymbol(_iconAfter);
+
+				iconAfterTag.doTag(pageContext);
+			}
+
 			return SKIP_BODY;
 		}
 
@@ -323,6 +347,7 @@ public class LinkTag extends BaseContainerTag {
 	private String _fontSize;
 	private String _href;
 	private String _icon;
+	private String _iconAfter;
 	private String _label;
 	private boolean _monospaced;
 	private boolean _outline;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1358,6 +1358,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>iconAfter</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>id</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
@@ -116,12 +116,14 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 								Group selUserGroup = selUser.getGroup();
 								%>
 
-								<liferay-ui:icon
-									label="<%= true %>"
-									message="open-pages"
-									method="get"
+								<clay:link
+									aria-label='<%= LanguageUtil.get(request, "go-to-profile-pages") + StringPool.SPACE + LanguageUtil.get(request, "opens-new-window") %>'
+									decoration="underline"
+									displayType="primary"
+									href="<%= selUserGroup.getDisplayURL(themeDisplay, false) %>"
+									iconAfter="shortcut"
+									label='<%= LanguageUtil.get(request, "my-profile") %>'
 									target="_blank"
-									url="<%= selUserGroup.getDisplayURL(themeDisplay, false) %>"
 								/>
 							</c:when>
 							<c:otherwise>
@@ -195,12 +197,14 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 								Group selUserGroup = selUser.getGroup();
 								%>
 
-								<liferay-ui:icon
-									label="<%= true %>"
-									message="open-pages"
-									method="get"
+								<clay:link
+									aria-label='<%= LanguageUtil.get(request, "go-to-dashboard-pages") + StringPool.SPACE + LanguageUtil.get(request, "opens-new-window") %>'
+									decoration="underline"
+									displayType="primary"
+									href="<%= selUserGroup.getDisplayURL(themeDisplay, true) %>"
+									iconAfter="shortcut"
+									label='<%= LanguageUtil.get(request, "my-dashboard") %>'
 									target="_blank"
-									url="<%= selUserGroup.getDisplayURL(themeDisplay, true) %>"
 								/>
 							</c:when>
 							<c:otherwise>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168532

I updated the links to recently changed Lexicon styles (for accessibility) in https://github.com/liferay/clay/issues/5283. I also changed the text from "Open Pages" to "My Profile" and "My Dashboard". I thought it would be more descriptive, let me know if I should change it back.

![profile-and-dashboard](https://user-images.githubusercontent.com/788266/219467301-13445e3f-a46f-4771-8ad6-6d22c65d9c77.gif)
