### PR TITLE
LPS-169100 HRG_26 My Profile exist multiple heading

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
@@ -31,7 +31,7 @@
 								<img alt="${logo_description}" class="mr-2" height="56" src="${site_logo}" />
 
 								<#if show_site_name>
-									<h1 class="font-weight-bold h2 mb-0 text-dark">${site_name}</h1>
+									<h1 <#if show_control_menu>aria-hidden="true"</#if> class="font-weight-bold h2 mb-0 text-dark">${site_name}</h1>
 								</#if>
 							</a>
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.ftl
@@ -39,6 +39,8 @@
 	company_logo_height = theme_display.getCompanyLogoHeight()
 	company_logo_width = theme_display.getCompanyLogoWidth()
 	company_url = theme_display.getURLHome()
+
+	show_control_menu = theme_display.isShowControlMenu()
 />
 
 <#if !request.isRequestedSessionIdFromCookie()>

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/events/ProductNavigationControlMenuServicePreAction.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/events/ProductNavigationControlMenuServicePreAction.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.product.navigation.control.menu.theme.contributor.internal.events;
+
+import com.liferay.portal.kernel.events.Action;
+import com.liferay.portal.kernel.events.ActionException;
+import com.liferay.portal.kernel.events.LifecycleAction;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.product.navigation.control.menu.theme.contributor.internal.util.ProductNavigationControlMenuUtil;
+import com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuCategoryRegistry;
+import com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuEntryRegistry;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@Component(
+	property = "key=servlet.service.events.pre", service = LifecycleAction.class
+)
+public class ProductNavigationControlMenuServicePreAction extends Action {
+
+	@Override
+	public void run(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws ActionException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		themeDisplay.setShowControlMenu(
+			ProductNavigationControlMenuUtil.isShowControlMenu(
+				httpServletRequest,
+				_productNavigationControlMenuCategoryRegistry,
+				_productNavigationControlMenuEntryRegistry));
+	}
+
+	@Reference
+	private ProductNavigationControlMenuCategoryRegistry
+		_productNavigationControlMenuCategoryRegistry;
+
+	@Reference
+	private ProductNavigationControlMenuEntryRegistry
+		_productNavigationControlMenuEntryRegistry;
+
+}

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/template/ProductNavigationControlMenuTemplateContextContributor.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/template/ProductNavigationControlMenuTemplateContextContributor.java
@@ -14,20 +14,12 @@
 
 package com.liferay.product.navigation.control.menu.theme.contributor.internal.template;
 
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.template.TemplateContextContributor;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuCategory;
-import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
-import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuCategoryKeys;
+import com.liferay.product.navigation.control.menu.theme.contributor.internal.util.ProductNavigationControlMenuUtil;
 import com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuCategoryRegistry;
 import com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuEntryRegistry;
 
-import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -50,7 +42,11 @@ public class ProductNavigationControlMenuTemplateContextContributor
 		Map<String, Object> contextObjects,
 		HttpServletRequest httpServletRequest) {
 
-		if (!_isShowControlMenu(httpServletRequest)) {
+		if (!ProductNavigationControlMenuUtil.isShowControlMenu(
+				httpServletRequest,
+				_productNavigationControlMenuCategoryRegistry,
+				_productNavigationControlMenuEntryRegistry)) {
+
 			return;
 		}
 
@@ -58,60 +54,6 @@ public class ProductNavigationControlMenuTemplateContextContributor
 			contextObjects.get("bodyCssClass"));
 
 		contextObjects.put("bodyCssClass", cssClass + " has-control-menu");
-	}
-
-	private boolean _isShowControlMenu(HttpServletRequest httpServletRequest) {
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		if (!themeDisplay.isSignedIn()) {
-			return false;
-		}
-
-		String layoutMode = ParamUtil.getString(
-			httpServletRequest, "p_l_mode", Constants.VIEW);
-
-		if (layoutMode.equals(Constants.PREVIEW)) {
-			return false;
-		}
-
-		User user = themeDisplay.getUser();
-
-		if (!themeDisplay.isImpersonated() && !user.isSetupComplete()) {
-			return false;
-		}
-
-		List<ProductNavigationControlMenuCategory>
-			productNavigationControlMenuCategories =
-				_productNavigationControlMenuCategoryRegistry.
-					getProductNavigationControlMenuCategories(
-						ProductNavigationControlMenuCategoryKeys.ROOT);
-
-		for (ProductNavigationControlMenuCategory
-				productNavigationControlMenuCategory :
-					productNavigationControlMenuCategories) {
-
-			List<ProductNavigationControlMenuEntry>
-				productNavigationControlMenuEntries =
-					_productNavigationControlMenuEntryRegistry.
-						getProductNavigationControlMenuEntries(
-							productNavigationControlMenuCategory,
-							httpServletRequest);
-
-			for (ProductNavigationControlMenuEntry
-					productNavigationControlMenuEntry :
-						productNavigationControlMenuEntries) {
-
-				if (productNavigationControlMenuEntry.isRelevant(
-						httpServletRequest)) {
-
-					return true;
-				}
-			}
-		}
-
-		return false;
 	}
 
 	@Reference

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/template/ProductNavigationControlMenuTemplateContextContributor.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/template/ProductNavigationControlMenuTemplateContextContributor.java
@@ -15,17 +15,15 @@
 package com.liferay.product.navigation.control.menu.theme.contributor.internal.template;
 
 import com.liferay.portal.kernel.template.TemplateContextContributor;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.product.navigation.control.menu.theme.contributor.internal.util.ProductNavigationControlMenuUtil;
-import com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuCategoryRegistry;
-import com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuEntryRegistry;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Julio Camarero
@@ -42,11 +40,11 @@ public class ProductNavigationControlMenuTemplateContextContributor
 		Map<String, Object> contextObjects,
 		HttpServletRequest httpServletRequest) {
 
-		if (!ProductNavigationControlMenuUtil.isShowControlMenu(
-				httpServletRequest,
-				_productNavigationControlMenuCategoryRegistry,
-				_productNavigationControlMenuEntryRegistry)) {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
+		if (!themeDisplay.isShowControlMenu()) {
 			return;
 		}
 
@@ -55,13 +53,5 @@ public class ProductNavigationControlMenuTemplateContextContributor
 
 		contextObjects.put("bodyCssClass", cssClass + " has-control-menu");
 	}
-
-	@Reference
-	private ProductNavigationControlMenuCategoryRegistry
-		_productNavigationControlMenuCategoryRegistry;
-
-	@Reference
-	private ProductNavigationControlMenuEntryRegistry
-		_productNavigationControlMenuEntryRegistry;
 
 }

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/util/ProductNavigationControlMenuUtil.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/util/ProductNavigationControlMenuUtil.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.product.navigation.control.menu.theme.contributor.internal.util;
+
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuCategory;
+import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
+import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuCategoryKeys;
+import com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuCategoryRegistry;
+import com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuEntryRegistry;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class ProductNavigationControlMenuUtil {
+
+	public static boolean isShowControlMenu(
+		HttpServletRequest httpServletRequest,
+		ProductNavigationControlMenuCategoryRegistry
+			productNavigationControlMenuCategoryRegistry,
+		ProductNavigationControlMenuEntryRegistry
+			productNavigationControlMenuEntryRegistry) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if (!themeDisplay.isSignedIn()) {
+			return false;
+		}
+
+		String layoutMode = ParamUtil.getString(
+			httpServletRequest, "p_l_mode", Constants.VIEW);
+
+		if (layoutMode.equals(Constants.PREVIEW)) {
+			return false;
+		}
+
+		User user = themeDisplay.getUser();
+
+		if (!themeDisplay.isImpersonated() && !user.isSetupComplete()) {
+			return false;
+		}
+
+		List<ProductNavigationControlMenuCategory>
+			productNavigationControlMenuCategories =
+				productNavigationControlMenuCategoryRegistry.
+					getProductNavigationControlMenuCategories(
+						ProductNavigationControlMenuCategoryKeys.ROOT);
+
+		for (ProductNavigationControlMenuCategory
+				productNavigationControlMenuCategory :
+					productNavigationControlMenuCategories) {
+
+			List<ProductNavigationControlMenuEntry>
+				productNavigationControlMenuEntries =
+					productNavigationControlMenuEntryRegistry.
+						getProductNavigationControlMenuEntries(
+							productNavigationControlMenuCategory,
+							httpServletRequest);
+
+			for (ProductNavigationControlMenuEntry
+					productNavigationControlMenuEntry :
+						productNavigationControlMenuEntries) {
+
+				if (productNavigationControlMenuEntry.isRelevant(
+						httpServletRequest)) {
+
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/ThemeDisplay.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/ThemeDisplay.java
@@ -1202,6 +1202,10 @@ public class ThemeDisplay
 		return _secure;
 	}
 
+	public boolean isShowControlMenu() {
+		return _showControlMenu;
+	}
+
 	public boolean isShowControlPanelIcon() {
 		return _showControlPanelIcon;
 	}
@@ -1707,6 +1711,10 @@ public class ThemeDisplay
 		_sessionId = sessionId;
 	}
 
+	public void setShowControlMenu(boolean showControlMenu) {
+		_showControlMenu = showControlMenu;
+	}
+
 	public void setShowControlPanelIcon(boolean showControlPanelIcon) {
 		_showControlPanelIcon = showControlPanelIcon;
 	}
@@ -2037,6 +2045,7 @@ public class ThemeDisplay
 	private String _serverName;
 	private int _serverPort;
 	private String _sessionId = StringPool.BLANK;
+	private boolean _showControlMenu;
 	private boolean _showControlPanelIcon;
 	private boolean _showHomeIcon;
 	private boolean _showLayoutTemplatesIcon;

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/packageinfo
@@ -1,1 +1,1 @@
-version 10.2.0
+version 10.3.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-169100

When we are logged in and in the editing mode the main header should be the h1 of the Control Menu, so when we have the Control Menu present we can remove the semantic of the site h1 adding `aria-hidden="true"` to the h1.

For that reason, a new variable called `show_control_menu` has been added to the `init.ftl` in the `frontend-theme-unstyled` module, used to condition this `aria-hidden`.