### PR TITLE
[TS] LPS-176155 Reading files in with UTF-8 to correctly encode special characters

### DIFF
--- a/modules/apps/portal-language/portal-language-override-web/src/main/java/com/liferay/portal/language/override/web/internal/portlet/action/ImportTranslationsMVCActionCommand.java
+++ b/modules/apps/portal-language/portal-language-override-web/src/main/java/com/liferay/portal/language/override/web/internal/portlet/action/ImportTranslationsMVCActionCommand.java
@@ -27,6 +27,9 @@ import com.liferay.portal.language.override.web.internal.constants.PLOPortletKey
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.InputStreamReader;
+
+import java.nio.charset.StandardCharsets;
 
 import java.util.Enumeration;
 import java.util.Objects;
@@ -91,7 +94,9 @@ public class ImportTranslationsMVCActionCommand extends BaseMVCActionCommand {
 
 		Properties languageProperties = new Properties();
 
-		languageProperties.load(new FileInputStream(file));
+		languageProperties.load(
+			new InputStreamReader(
+				new FileInputStream(file), StandardCharsets.UTF_8));
 
 		if (languageProperties.size() == 0) {
 			SessionErrors.add(actionRequest, "fileInvalid");


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-176155

**Issue:**
Customer reported that when they import a language file that contains cyrillic letters (but it is also true for all special letters) the value belonging to the language key is saved with wrong encoding. (ex.: Ã© instead of é)

**Solution:**
Change the existing file input reader to an InputStreamReader that enforces UTF-8 encoding.

I tested it in my local environment and the solution worked as expected, both cyrillic and other (hungarian) special charecters were saved and displayed correctly.

Please review my PR!

Best regards,
Évi