### PR TITLE
LPS-179093 - Addresses related to a deleted account are not being deleted along with it 

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryLocalServiceImpl.java
@@ -63,6 +63,7 @@ import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
@@ -343,6 +344,12 @@ public class AccountEntryLocalServiceImpl
 		_resourceLocalService.deleteResource(
 			accountEntry.getCompanyId(), AccountEntry.class.getName(),
 			ResourceConstants.SCOPE_INDIVIDUAL,
+			accountEntry.getAccountEntryId());
+
+		// Addresses
+
+		_addressLocalService.deleteAddresses(
+			accountEntry.getCompanyId(), AccountEntry.class.getName(),
 			accountEntry.getAccountEntryId());
 
 		// Asset
@@ -1243,6 +1250,9 @@ public class AccountEntryLocalServiceImpl
 	@Reference
 	private AccountEntryEmailAddressValidatorFactory
 		_accountEntryEmailAddressValidatorFactory;
+
+	@Reference
+	private AddressLocalService _addressLocalService;
 
 	@Reference
 	private AssetEntryLocalService _assetEntryLocalService;


### PR DESCRIPTION
**Context:**
https://issues.liferay.com/browse/LPS-179093

**Steps:**
1. Go to Control Panel/Accounts and create an account.
2. In the Addresses tab, add an address to this account.
_Checkpoint:_ check the new rows created in the AccounteEntry and Address database tables.
3. Delete the account and check the 2 db tables again.

_**Result:**_ you can still see the row in the address table (with classnameid and classpK pointing to the deleted account)
_**Expected:**_ the address should be deleted from the database as well